### PR TITLE
feat: improve grader group rotation and existing grades handling

### DIFF
--- a/scripts/check-staff-rotation.mjs
+++ b/scripts/check-staff-rotation.mjs
@@ -1,4 +1,4 @@
-// scripts/check-staff-rotation.mjs
+// scripts/check-staff-columns.mjs
 import { createClient } from '@supabase/supabase-js';
 import * as dotenv from 'dotenv';
 
@@ -7,136 +7,47 @@ dotenv.config({ path: '.env.local' });
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-if (!supabaseUrl || !supabaseServiceKey) {
-  console.error('❌ Faltan credenciales');
-  process.exit(1);
-}
-
 const supabase = createClient(supabaseUrl, supabaseServiceKey, {
-  auth: { autoRefreshToken: false, persistSession: false }
+  auth: { autoRefreshToken: false, persistSession: false },
 });
 
-async function checkStaffRotation() {
-  console.log('🔍 === VERIFICANDO STAFF ID 30 ===\n');
+async function run() {
+  console.log('URL:', supabaseUrl);
+  console.log('--- Checking Staff columns ---');
 
-  // 1. Buscar Staff 30
-  const { data: staff30, error: staffError } = await supabase
+  const { data, error } = await supabase
     .from('Staff')
     .select('*')
-    .eq('ID_Staff', 30)
+    .limit(1)
     .maybeSingle();
 
-  if (staffError) {
-    console.error('❌ Error consultando Staff:', staffError.message);
+  if (error) {
+    console.error('❌ Error reading Staff:', error.message);
     return;
   }
 
-  if (!staff30) {
-    console.log('⚠️  No existe Staff con ID=30');
-    console.log('\n📋 Listando todos los Staff (calificadores):');
-    
-    const { data: allStaff } = await supabase
+  if (!data) {
+    console.log('⚠️ No rows in Staff, but table exists. Columns:');
+    const { data: cols, error: colsError } = await supabase
       .from('Staff')
-      .select('ID_Staff, Correo_Staff, Rol_Staff, ID_Assessment, ID_GrupoAssessment, Rotaciones_Staff')
-      .eq('Rol_Staff', 'calificador')
-      .order('ID_Staff');
-    
-    if (allStaff && allStaff.length > 0) {
-      console.table(allStaff);
-    } else {
-      console.log('No hay calificadores registrados');
-    }
-    return;
-  }
-
-  console.log('✅ Staff encontrado:');
-  console.log(JSON.stringify(staff30, null, 2));
-
-  // 2. Verificar el grupo 4
-  console.log('\n\n🔍 === VERIFICANDO GRUPO ID 4 ===\n');
-  const { data: grupo4, error: grupoError } = await supabase
-    .from('GrupoAssessment')
-    .select('*')
-    .eq('ID_GrupoAssessment', 4)
-    .maybeSingle();
-
-  if (grupoError) {
-    console.error('❌ Error consultando Grupo:', grupoError.message);
-    return;
-  }
-
-  if (!grupo4) {
-    console.log('⚠️  No existe Grupo con ID=4');
-    return;
-  }
-
-  console.log('✅ Grupo encontrado:');
-  console.log(JSON.stringify(grupo4, null, 2));
-
-  // 3. Validar compatibilidad
-  console.log('\n\n🧪 === VALIDACIÓN DE COMPATIBILIDAD ===\n');
-  
-  if (staff30.ID_Assessment === grupo4.ID_Assessment) {
-    console.log('✅ El Staff y el Grupo pertenecen al mismo Assessment');
-    console.log(`   Assessment ID: ${staff30.ID_Assessment}`);
-    console.log('\n✅ La actualización DEBERÍA funcionar');
-  } else {
-    console.log('❌ PROBLEMA DE FOREIGN KEY:');
-    console.log(`   Staff 30 está en Assessment ${staff30.ID_Assessment}`);
-    console.log(`   Grupo 4 está en Assessment ${grupo4.ID_Assessment}`);
-    console.log('\n❌ PostgreSQL rechazará esta actualización');
-  }
-
-  // 4. Listar grupos del mismo assessment que el staff
-  console.log(`\n\n📋 === GRUPOS DISPONIBLES PARA ASSESSMENT ${staff30.ID_Assessment} ===\n`);
-  const { data: gruposDisponibles } = await supabase
-    .from('GrupoAssessment')
-    .select('ID_GrupoAssessment, Nombre_GrupoAssessment, ID_Assessment')
-    .eq('ID_Assessment', staff30.ID_Assessment)
-    .order('ID_GrupoAssessment');
-
-  if (gruposDisponibles && gruposDisponibles.length > 0) {
-    console.table(gruposDisponibles);
-  } else {
-    console.log('⚠️  No hay grupos en este Assessment');
-  }
-
-  // 5. Intentar el UPDATE (simulación)
-  console.log('\n\n🧪 === SIMULANDO UPDATE ===\n');
-  console.log('Payload enviado:');
-  console.log(JSON.stringify({
-    staffId: 30,
-    grupoAssessmentId: 4,
-    rotaciones: 0
-  }, null, 2));
-
-  try {
-    const { data: result, error: updateError } = await supabase
-      .from('Staff')
-      .update({
-        ID_GrupoAssessment: 4,
-        Rotaciones_Staff: 0
-      })
-      .eq('ID_Staff', 30)
       .select('*')
-      .single();
-
-    if (updateError) {
-      console.log('\n❌ Error en UPDATE:');
-      console.log('Código:', updateError.code);
-      console.log('Mensaje:', updateError.message);
-      console.log('Detalles:', updateError.details);
-      console.log('Hint:', updateError.hint);
+      .limit(0);
+    if (colsError) {
+      console.error('Error introspecting Staff:', colsError.message);
     } else {
-      console.log('\n✅ UPDATE exitoso:');
-      console.log(JSON.stringify(result, null, 2));
+      console.log(Object.keys(cols));
     }
-  } catch (err) {
-    console.error('❌ Excepción:', err);
+    return;
   }
+
+  const cols = Object.keys(data);
+  console.log('Columns in Staff:', cols);
+
+  console.log('\nHas ID_GrupoAssessment?', cols.includes('ID_GrupoAssessment'));
+  console.log('Has Rotaciones_Staff?', cols.includes('Rotaciones_Staff'));
+
+  console.log('\nSample row:');
+  console.log(JSON.stringify(data, null, 2));
 }
 
-checkStaffRotation().then(() => {
-  console.log('\n✅ Diagnóstico completado');
-  process.exit(0);
-});
+run();

--- a/scripts/migrate-staff-add-group.mjs
+++ b/scripts/migrate-staff-add-group.mjs
@@ -1,0 +1,80 @@
+// scripts/migrate-staff-add-group.mjs
+import { createClient } from '@supabase/supabase-js';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceKey) {
+  console.error('❌ Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function run() {
+  console.log('🚀 Running Staff migration on:', supabaseUrl);
+
+  const sql = `
+    ALTER TABLE public."Staff"
+    ADD COLUMN IF NOT EXISTS "ID_GrupoAssessment" integer NULL;
+
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'FK_Staff_GrupoAssessment'
+      ) THEN
+        ALTER TABLE public."Staff"
+        ADD CONSTRAINT "FK_Staff_GrupoAssessment"
+        FOREIGN KEY ("ID_GrupoAssessment")
+        REFERENCES public."GrupoAssessment"("ID_GrupoAssessment")
+        ON UPDATE RESTRICT
+        ON DELETE SET NULL;
+      END IF;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "IX_Staff_GrupoAssessment"
+    ON public."Staff" ("ID_GrupoAssessment");
+  `;
+
+  try {
+    const { error } = await supabase.rpc('exec_sql', { sql });
+
+    if (error) {
+      console.error('❌ Error executing SQL via exec_sql:', error.message);
+      console.log('\nIf exec_sql is not defined, paste this SQL manually in Supabase SQL editor:\n');
+      console.log(sql);
+      process.exit(1);
+    }
+
+    console.log('✅ Migration executed successfully');
+
+    const { data, error: sampleError } = await supabase
+      .from('Staff')
+      .select('*')
+      .limit(1)
+      .maybeSingle();
+
+    if (sampleError) {
+      console.error('⚠️ Could not read Staff after migration:', sampleError.message);
+    } else if (data) {
+      const cols = Object.keys(data);
+      console.log('📊 Columns now in Staff:', cols);
+      console.log('Has ID_GrupoAssessment?', cols.includes('ID_GrupoAssessment'));
+    } else {
+      console.log('⚠️ Staff has no rows yet, but migration should be applied.');
+    }
+  } catch (err) {
+    console.error('❌ Unexpected error during migration:', err);
+    console.log('\n📝 If RPC is not available, run this SQL manually in Supabase:\n');
+    console.log(sql);
+  }
+}
+
+run();

--- a/src/app/dashboard/rotations/page.tsx
+++ b/src/app/dashboard/rotations/page.tsx
@@ -11,10 +11,14 @@ type StaffRow = {
   correo: string;
   rol: string;
   assessmentId: number;
+  baseId: number | null;
+  baseNombre: string | null;
+  baseNumero: number | null;
   grupoId: number | null;
   grupoNombre: string | null;
   rotaciones: number;
 };
+
 
 type GrupoItem = { id: number; nombre: string };
 
@@ -130,7 +134,6 @@ export default function RotationsDashboard() {
           body: JSON.stringify({
             staffId: editModal.id,
             grupoAssessmentId: editModal.grupoId,
-            rotaciones: editModal.rotaciones,
           }),
         },
         () => logout()
@@ -269,8 +272,8 @@ export default function RotationsDashboard() {
               <th className="p-3 text-left text-sm">ID</th>
               <th className="p-3 text-left text-sm">Correo</th>
               <th className="p-3 text-left text-sm">Assessment</th>
+              <th className="p-3 text-left text-sm">Base</th>
               <th className="p-3 text-left text-sm">Grupo</th>
-              <th className="p-3 text-left text-sm">Rotaciones</th>
               <th className="p-3 text-left text-sm">Acciones</th>
             </tr>
           </thead>
@@ -284,9 +287,13 @@ export default function RotationsDashboard() {
                 <td className="p-3">{item.correo}</td>
                 <td className="p-3">{item.assessmentId}</td>
                 <td className="p-3">
+                  {item.baseNombre 
+                    ? `${item.baseNumero ? `Base ${item.baseNumero}: ` : ''}${item.baseNombre}` 
+                    : "Sin base"}
+                </td>
+                <td className="p-3">
                   {item.grupoNombre ?? (item.grupoId ? `Grupo ${item.grupoId}` : "Sin grupo")}
                 </td>
-                <td className="p-3">{item.rotaciones ?? 0}</td>
                 <td className="p-3">
                   <button
                     className="bg-[color:var(--color-accent)] text-white px-4 py-2 rounded text-sm hover:bg-[#5B21B6] transition shadow"
@@ -323,11 +330,15 @@ export default function RotationsDashboard() {
                 <span className="font-semibold">Assessment:</span> {item.assessmentId}
               </p>
               <p>
+                <span className="font-semibold">Base:</span>{" "}
+                {item.baseNombre 
+                  ? `${item.baseNumero ? `Base ${item.baseNumero}: ` : ''}${item.baseNombre}` 
+                  : "Sin base"}
+              </p>
+              
+              <p>
                 <span className="font-semibold">Grupo:</span>{" "}
                 {item.grupoNombre ?? (item.grupoId ? `Grupo ${item.grupoId}` : "Sin grupo")}
-              </p>
-              <p>
-                <span className="font-semibold">Rotaciones:</span> {item.rotaciones ?? 0}
               </p>
             </div>
             <button
@@ -370,19 +381,6 @@ export default function RotationsDashboard() {
                   </option>
                 ))}
               </select>
-
-              <label className="block mb-2 font-semibold text-white text-sm sm:text-base">
-                Rotaciones
-              </label>
-              <input
-                type="number"
-                min={0}
-                value={editModal.rotaciones ?? 0}
-                onChange={(e) =>
-                  setEditModal({ ...editModal, rotaciones: Number(e.target.value) })
-                }
-                className="w-full border-2 border-primary px-3 py-2 rounded mb-4 text-black bg-white text-sm sm:text-base"
-              />
 
               <div className="flex justify-end gap-2">
                 <button

--- a/src/pages/api/dashboard/rotations.ts
+++ b/src/pages/api/dashboard/rotations.ts
@@ -7,9 +7,8 @@ type StaffRow = {
   Correo_Staff: string;
   Rol_Staff: string;
   ID_Assessment: number;
+  ID_Base?: number | null;
   ID_GrupoAssessment?: number | null;
-  Rotaciones_Staff?: number | null;
-  Grupo?: { Nombre_GrupoAssessment?: string | null } | null;
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -22,78 +21,95 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     const assessmentId = req.query.assessmentId ? Number(req.query.assessmentId) : null;
 
-    const baseSelect = "ID_Staff, Correo_Staff, Rol_Staff, ID_Assessment";
-    const fullSelect = "ID_Staff, Correo_Staff, Rol_Staff, ID_Assessment, ID_GrupoAssessment, Rotaciones_Staff";
+    const fullSelect = "ID_Staff, Correo_Staff, Rol_Staff, ID_Assessment, ID_Base, ID_GrupoAssessment";
 
     let query = supabase
       .from("Staff")
       .select(fullSelect)
       .eq("Rol_Staff", "calificador")
       .order("ID_Staff", { ascending: true });
+    
     if (assessmentId) {
       query = query.eq("ID_Assessment", assessmentId);
     }
 
-    let { data, error } = await query;
+    const { data, error } = await query;
 
     if (error) {
-      const shouldFallback =
-        error.message.toLowerCase().includes("column") ||
-        error.message.includes("ID_GrupoAssessment") ||
-        error.message.includes("Rotaciones_Staff");
-
-      if (shouldFallback) {
-        let fallbackQuery = supabase
-          .from("Staff")
-          .select(baseSelect)
-          .eq("Rol_Staff", "calificador")
-          .order("ID_Staff", { ascending: true });
-        if (assessmentId) {
-          fallbackQuery = fallbackQuery.eq("ID_Assessment", assessmentId);
-        }
-        const fallback = await fallbackQuery;
-        if (fallback.error) throw fallback.error;
-        data = (fallback.data as StaffRow[])?.map((row) => ({
-          ...row,
-          ID_GrupoAssessment: null,
-          Rotaciones_Staff: null,
-        }));
-      } else {
-        throw error;
-      }
+      console.error("❌ Error en query inicial:", error);
+      throw error;
     }
 
+    console.log("✅ Data obtenida:", data?.length, "calificadores");
+    console.log("📊 Ejemplo de data:", data?.[0]);
+
+    // Obtener nombres de grupos
     let groupNameById = new Map<number, string>();
-    const hasGroupColumn = (data as StaffRow[] | null)?.some(
-      (row) => row.ID_GrupoAssessment !== undefined
-    );
-    if (hasGroupColumn) {
-      const groupIds = (data as StaffRow[] | null)
-        ?.map((row) => row.ID_GrupoAssessment)
-        .filter((id): id is number => typeof id === "number");
-      if (groupIds && groupIds.length > 0) {
-        const { data: groups, error: groupsError } = await supabase
-          .from("GrupoAssessment")
-          .select("ID_GrupoAssessment, Nombre_GrupoAssessment")
-          .in("ID_GrupoAssessment", Array.from(new Set(groupIds)));
-        if (!groupsError && groups) {
-          for (const group of groups) {
-            groupNameById.set(group.ID_GrupoAssessment as number, group.Nombre_GrupoAssessment as string);
-          }
+    const groupIds = (data as StaffRow[])
+      ?.map((row) => row.ID_GrupoAssessment)
+      .filter((id): id is number => typeof id === "number" && id !== null);
+    
+    console.log("🔍 Group IDs encontrados:", groupIds);
+
+    if (groupIds && groupIds.length > 0) {
+      const { data: groups, error: groupsError } = await supabase
+        .from("GrupoAssessment")
+        .select("ID_GrupoAssessment, Nombre_GrupoAssessment")
+        .in("ID_GrupoAssessment", Array.from(new Set(groupIds)));
+      
+      console.log("📦 Grupos obtenidos:", groups);
+      
+      if (!groupsError && groups) {
+        for (const group of groups) {
+          groupNameById.set(group.ID_GrupoAssessment as number, group.Nombre_GrupoAssessment as string);
         }
+      } else if (groupsError) {
+        console.error("❌ Error obteniendo grupos:", groupsError);
       }
     }
 
-    const payload = (data as StaffRow[] | null)?.map((staff) => ({
+    // ✅ Obtener información de las bases
+    let baseInfoById = new Map<number, { nombre: string; numero: number }>();
+    const baseIds = (data as StaffRow[])
+      ?.map((row) => row.ID_Base)
+      .filter((id): id is number => typeof id === "number" && id !== null);
+    
+    console.log("🔍 Base IDs encontrados:", baseIds);
+
+    if (baseIds && baseIds.length > 0) {
+      const { data: bases, error: basesError } = await supabase
+        .from("Bases")
+        .select("ID_Base, Nombre_Base, Numero_Base")
+        .in("ID_Base", Array.from(new Set(baseIds)));
+      
+      console.log("📦 Bases obtenidas:", bases);
+      
+      if (!basesError && bases) {
+        for (const base of bases) {
+          baseInfoById.set(base.ID_Base as number, {
+            nombre: base.Nombre_Base as string,
+            numero: base.Numero_Base as number,
+          });
+        }
+      } else if (basesError) {
+        console.error("❌ Error obteniendo bases:", basesError);
+      }
+    }
+
+    const payload = (data as StaffRow[])?.map((staff) => ({
       id: staff.ID_Staff,
       correo: staff.Correo_Staff,
       rol: staff.Rol_Staff,
       assessmentId: staff.ID_Assessment,
+      baseId: staff.ID_Base ?? null,
+      baseNombre: staff.ID_Base != null ? (baseInfoById.get(staff.ID_Base)?.nombre ?? null) : null,
+      baseNumero: staff.ID_Base != null ? (baseInfoById.get(staff.ID_Base)?.numero ?? null) : null,
       grupoId: staff.ID_GrupoAssessment ?? null,
       grupoNombre:
         staff.ID_GrupoAssessment != null ? groupNameById.get(staff.ID_GrupoAssessment) ?? null : null,
-      rotaciones: staff.Rotaciones_Staff ?? 0,
     })) ?? [];
+
+    console.log("📤 Payload final (primero):", payload[0]);
 
     res.status(200).json(payload);
   } catch (error) {

--- a/src/pages/api/get-calificaciones-by-calificador.ts
+++ b/src/pages/api/get-calificaciones-by-calificador.ts
@@ -1,0 +1,81 @@
+// src/pages/api/get-calificaciones-by-calificador.ts
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabaseServer';
+import { requireRoles } from '@/lib/apiAuth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método no permitido' });
+  }
+
+  // Verificar autenticación
+  if (!requireRoles(req, res, ['admin', 'calificador'])) return;
+
+  try {
+    const { idCalificador, idBase } = req.body;
+
+    // Validar parámetros
+    if (!idCalificador || !idBase) {
+      console.error('❌ Faltan parámetros:', { idCalificador, idBase });
+      return res.status(400).json({ error: 'idCalificador e idBase son obligatorios' });
+    }
+
+    const calificadorId = Number(idCalificador);
+    const baseId = Number(idBase);
+
+    if (Number.isNaN(calificadorId) || Number.isNaN(baseId)) {
+      console.error('❌ Parámetros inválidos:', { idCalificador, idBase });
+      return res.status(400).json({ error: 'Los parámetros deben ser números válidos' });
+    }
+
+    // Obtener el assessment del calificador
+    const { data: staff, error: staffError } = await supabase
+      .from('Staff')
+      .select('ID_Assessment')
+      .eq('ID_Staff', calificadorId)
+      .single();
+
+    if (staffError) {
+      console.error('❌ Error al buscar Staff:', staffError);
+      return res.status(404).json({ error: 'No se encontró el calificador', details: staffError.message });
+    }
+
+    if (!staff) {
+      console.error('❌ Staff no encontrado para ID:', calificadorId);
+      return res.status(404).json({ error: 'No se encontró el calificador' });
+    }
+
+    const assessmentId = staff.ID_Assessment;
+
+    // Obtener todas las calificaciones de este calificador para esta base
+    const { data: calificaciones, error: gradesError } = await supabase
+      .from('CalificacionesPorPersona')
+      .select('ID_Participante, Calificacion_1, Calificacion_2, Calificacion_3')
+      .eq('ID_Assessment', assessmentId)
+      .eq('ID_Base', baseId)
+      .eq('ID_Staff', calificadorId);
+
+    if (gradesError) {
+      console.error('❌ Error al obtener calificaciones:', gradesError);
+      return res.status(500).json({ 
+        error: 'Error al obtener calificaciones', 
+        details: gradesError.message 
+      });
+    }
+
+    console.log('✅ Calificaciones encontradas:', calificaciones?.length || 0);
+    
+    return res.status(200).json({ 
+      calificaciones: calificaciones || [],
+      count: calificaciones?.length || 0
+    });
+
+  } catch (error) {
+    console.error('❌ Error inesperado en get-calificaciones-by-calificador:', error);
+    return res.status(500).json({
+      error: 'Error interno del servidor',
+      details: (error as Error).message,
+    });
+  }
+}


### PR DESCRIPTION
- Validate grading per base and per grader group instead of only by base
- Align add-calificaciones logic with check-already-graded using group participants
- Remove all usages of obsolete Rotaciones_Staff field in backend and scripts
- Add support for base metadata (id, number, name) in dashboard rotations API
- Expose grader's existing grades via get-calificaciones-by-calificador endpoint
- Autoload existing grades on graderPage when alreadyGraded is true, with loading state
- Show assigned base information in dashboard/rotations UI
- Add migration helper script to introduce ID_GrupoAssessment on Staff when available