### PR TITLE
Add assessment filter and make dashboard config fully dynamic

### DIFF
--- a/src/app/dashboard/config/page.tsx
+++ b/src/app/dashboard/config/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { useAdminAuth } from '../../Hooks/useAdminAuth';
 import { useRouter } from 'next/navigation';
 import { Spinner } from '../../components/UI/Loading';
@@ -56,11 +56,14 @@ export default function Dashboard() {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterGrupo, setFilterGrupo] = useState<string>("todos");
   const [filterRol, setFilterRol] = useState<string>("todos");
-  const [filterAssessment, setFilterAssessment] = useState<string>("todos");
+  const [filterAssessment, setFilterAssessment] = useState<string>("default");
   const [sortBy, setSortBy] = useState<"nombre" | "promedio" | "grupo">("nombre");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 12;
+
+  // AbortController ref to cancel in-flight fetchData requests
+  const fetchAbortRef = useRef<AbortController | null>(null);
 
   // Proteger la ruta - redirige si no es admin
   useEffect(() => {
@@ -68,6 +71,16 @@ export default function Dashboard() {
   }, [isAdmin, authLoading]);
 
   const fetchData = async (assessmentId?: string) => {
+    // Cancel any in-flight request
+    if (fetchAbortRef.current) {
+      fetchAbortRef.current.abort();
+      fetchAbortRef.current = null;
+    }
+    const controller = new AbortController();
+    fetchAbortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
     try {
       const url = assessmentId
         ? `/api/dashboard/config?assessmentId=${assessmentId}`
@@ -75,9 +88,11 @@ export default function Dashboard() {
 
       const response = await authFetch(
         url,
-        { headers: { ...getAuthHeaders() } },
+        { headers: { ...getAuthHeaders() }, signal: controller.signal },
         () => logout()
       );
+
+      if (controller.signal.aborted) return;
 
       if (response.status === 401) {
         router.push('/auth/login');
@@ -89,6 +104,10 @@ export default function Dashboard() {
       setData(result);
       setLoading(false);
     } catch (err: unknown) {
+      if ((err as Error)?.name === 'AbortError') {
+        setLoading(false);
+        return;
+      }
       const message = err instanceof Error ? err.message : 'Error al cargar los datos';
       if (message.toLowerCase().includes('no autorizado')) {
         router.push('/auth/login');
@@ -96,6 +115,10 @@ export default function Dashboard() {
       }
       setError('Error al cargar los datos');
       setLoading(false);
+    } finally {
+      if (fetchAbortRef.current === controller) {
+        fetchAbortRef.current = null;
+      }
     }
   };
 
@@ -915,8 +938,8 @@ export default function Dashboard() {
               onChange={(e) => {
                 const value = e.target.value;
                 setFilterAssessment(value);
-                if (value === "todos") {
-                  // Si quieres, aquí podrías recargar sin filtro:
+                setCurrentPage(1);
+                if (value === "default") {
                   fetchData(undefined);
                 } else {
                   fetchData(value);
@@ -924,7 +947,7 @@ export default function Dashboard() {
               }}
               className="px-3 py-2 rounded-lg bg-white text-gray-900 border border-gray-300 text-base"
             >
-              <option value="todos" className="text-black">Todos los assessments</option>
+              <option value="default" className="text-black">Assessment por defecto</option>
               {visibleAssessments.map((assessment) => (
                 <option key={assessment.id} value={assessment.id} className="text-black">
                   {assessment.nombre}

--- a/src/app/dashboard/gh/page.tsx
+++ b/src/app/dashboard/gh/page.tsx
@@ -701,7 +701,8 @@ export default function GhDashboard() {
             </div>
 
             <div
-              className={`grid grid-cols-${item.Bases.length || 1} gap-1 text-sm text-center mb-3`}
+              style={{ gridTemplateColumns: `repeat(${item.Bases.length || 1}, minmax(0, 1fr))` }}
+              className="grid gap-1 text-sm text-center mb-3"
             >
               {item.Bases.map((base) => (
                 <div key={base.numero}>

--- a/src/pages/api/dashboard/config.ts
+++ b/src/pages/api/dashboard/config.ts
@@ -9,15 +9,30 @@ import { resolveParticipantPhotoUrls } from "@/lib/participantPhotoUrl";
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     if (!requireRoles(req, res, ["admin"])) return;
-    const assessmentId = req.query.assessmentId 
-    ? Number(req.query.assessmentId) 
-    : await getDefaultAssessmentId();
+    const rawAssessmentId = Array.isArray(req.query.assessmentId)
+      ? req.query.assessmentId[0]
+      : req.query.assessmentId;
+    const parsedAssessmentId = rawAssessmentId ? Number(rawAssessmentId) : null;
+    if (parsedAssessmentId !== null && !Number.isFinite(parsedAssessmentId)) {
+      return res.status(400).json({ error: "assessmentId inválido" });
+    }
+    const assessmentId = parsedAssessmentId ?? await getDefaultAssessmentId();
 
     const { data: assessment, error: assessmentError } = await supabase
     .from('Assessment')
     .select('ID_Assessment, Nombre_Assessment')
     .eq('ID_Assessment', assessmentId)
     .single();
+
+    if (assessmentError) {
+      console.error("❌ Error al obtener el assessment:", assessmentError);
+      return res.status(500).json({ error: "Error al obtener el assessment" });
+    }
+
+    if (!assessment) {
+      console.warn(`⚠️ Assessment no encontrado para ID ${assessmentId}`);
+      return res.status(404).json({ error: "Assessment no encontrado" });
+    }
 
     const { data: participantes, error: participantesError } = await supabase
       .from('Participante')

--- a/src/pages/api/dashboard/gh.ts
+++ b/src/pages/api/dashboard/gh.ts
@@ -81,6 +81,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             promedio: prom as number | null,
           };
         })
+        .filter((b) => Number.isFinite(b.numero))
         .sort((a, b) => a.numero - b.numero);
 
       const promedio = generalPromByPersona[p.ID_Participante] ?? null;


### PR DESCRIPTION
This PR improves the admin dashboard config page to better support multi‑assessment scenarios and more flexible data loading.
**Main changes**:
- Add an assessment select filter to the dashboard config page to choose which assessment’s participants are shown.
- Wire the assessment filter to the backend by passing assessmentId as a query param to /api/dashboard/config and reusing the same fetch logic.
- Extract a reusable fetchData helper from the existing useEffect to reload dashboard data on demand when the selected assessment changes.
- Keep existing group and role filters working on top of the currently selected assessment, preserving the previous behavior for single‑assessment use.
- Align assessment select styling with the existing group and role selects so the filters row looks consistent in the UI.

**Notes**:
- This is a first step toward full multi‑assessment support on the dashboard; some API endpoints still rely on getDefaultAssessmentId and will need follow‑up refactors later.