### PR TITLE
feat(auth): migrate to HttpOnly cookies and fix register bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Para entender la arquitectura, el dominio y cómo contribuir, consulta los sigui
 3.  **Tests:** `npm test` para ejecutar la suite de pruebas.
 4.  **Variables de Env:** Copia `.env.example` a `.env.local` y completa los valores.
 5.  **Desarrollo:** `npm run dev` abre `http://localhost:3000`.
+6.  **Datos Mock:** (Opcional) `npm run db:seed` genera un assessment y calificadores temporales para poder probar.
 
 ---
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -39,7 +39,7 @@ Para probar las funcionalidades de **Admin**, **Registrador** o **Calificador** 
 
 ## Solución de Problemas Comunes (FAQ)
 
-- **"Recibo un error 401 al llamar a las APIs":** Verifica que tu token JWT sea válido. Si has reiniciado Supabase o cambiado el `JWT_SECRET`, limpia el `localStorage` de tu navegador.
+- **"Recibo un error 401 al llamar a las APIs":** Verifica que tu cookie de sesión siga activa. Si has reiniciado Supabase o cambiado el `JWT_SECRET`, borra la cookie `session` desde el panel de Application/Cookies en las DevTools de tu navegador, o simplemente vuelve a iniciar sesión para sobreescribirla.
 - **"El build falla por variables faltantes":** Next.js requiere ciertas variables en tiempo de compilación. Asegúrate de que `.env.local` esté completo antes de ejecutar `npm run build`.
 - **"No puedo ver assessments en el panel admin":** Recuerda que los admins ahora están filtrados por `ID_GrupoEstudiantil` (**ADR 0002**). Verifica que tu usuario staff tenga asignado un grupo que posea assessments.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,8 +7,8 @@ Este documento recopila problemas comunes y sus soluciones para ahorrarte tiempo
 ## Autenticación y Acceso
 
 ### ¿Por qué recibo 401 localmente si mis credenciales son correctas?
-- Causa 1: El token JWT en el localStorage ha expirado o ya no coincide con el JWT_SECRET de Supabase.
-- Solución: Limpia el localStorage y vuelve a iniciar sesión.
+- Causa 1: El token JWT en la cookie `session` ha expirado o ya no coincide con el JWT_SECRET de Supabase.
+- Solución: Vuelve a iniciar sesión desde `/auth/login` (esto limpia y reemplaza la cookie automáticamente), o bórrala en la pestaña de Application de tu navegador.
 - Causa 2: El flag Active del usuario staff en la DB puede estar impidiendo un nuevo login (si la lógica de "sesión única" está activa).
 - Solución: Ve a la tabla Staff en Supabase y pon Active = false.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.93.2",
         "bcryptjs": "^3.0.3",
         "browser-image-compression": "^2.0.2",
+        "cookie": "^1.1.1",
         "csv-stringify": "^6.6.0",
         "dotenv": "^17.3.1",
         "file-saver": "^2.0.5",
@@ -33,6 +34,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/bcryptjs": "^2.4.6",
+        "@types/cookie": "^0.6.0",
         "@types/file-saver": "^2.0.7",
         "@types/formidable": "^3.4.5",
         "@types/jsonwebtoken": "^9.0.10",
@@ -3118,6 +3120,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4968,6 +4977,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
     "start": "next start",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
-    "schema:dump": "node scripts/dump-schema.mjs"
+    "schema:dump": "node scripts/dump-schema.mjs",
+    "db:seed": "npx tsx scripts/seed-test-data.ts"
   },
   "dependencies": {
     "@azure/storage-blob": "^12.28.0",
     "@supabase/supabase-js": "^2.93.2",
     "bcryptjs": "^3.0.3",
     "browser-image-compression": "^2.0.2",
+    "cookie": "^1.1.1",
     "csv-stringify": "^6.6.0",
     "dotenv": "^17.3.1",
     "file-saver": "^2.0.5",
@@ -36,6 +38,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/bcryptjs": "^2.4.6",
+    "@types/cookie": "^0.6.0",
     "@types/file-saver": "^2.0.7",
     "@types/formidable": "^3.4.5",
     "@types/jsonwebtoken": "^9.0.10",

--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -1,0 +1,177 @@
+import { createClient } from '@supabase/supabase-js';
+import * as dotenv from 'dotenv';
+import bcrypt from 'bcryptjs';
+
+// Cargar variables de entorno desde .env.local
+dotenv.config({ path: '.env.local' });
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('❌ Faltan las variables de entorno de Supabase en .env.local');
+  process.exit(1);
+}
+
+// Cliente con Service Role
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function seedTestData() {
+  console.log('🌱 Iniciando la generación de datos de prueba...');
+
+  try {
+    // 1. Obtener o crear un Grupo Estudiantil Dummy
+    let { data: grupoEstudiantil } = await supabase
+      .from('GrupoEstudiantil')
+      .select('ID_GrupoEstudiantil')
+      .limit(1)
+      .single();
+
+    if (!grupoEstudiantil) {
+      console.log('Creando Grupo Estudiantil por defecto...');
+      const { data, error } = await supabase
+        .from('GrupoEstudiantil')
+        .insert({
+          Nombre_GrupoEstudiantil: 'Grupo de Prueba Global',
+          Descripcion_GrupoEstudiantil: 'Creado para testing'
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      grupoEstudiantil = data;
+    }
+
+    const { ID_GrupoEstudiantil } = grupoEstudiantil!;
+
+    // 2. Crear Assessment de Prueba
+    console.log('Creando Assessment...');
+    const { data: assessment, error: assessmentError } = await supabase
+      .from('Assessment')
+      .insert({
+        ID_GrupoEstudiantil,
+        Nombre_Assessment: `Assessment de Prueba ${Date.now()}`,
+        Descripcion_Assessment: 'Assessment generado automáticamente para desarrollo local',
+        Activo_Assessment: true
+      })
+      .select()
+      .single();
+    if (assessmentError) throw assessmentError;
+
+    const { ID_Assessment } = assessment;
+
+    // 3. Crear una Base
+    console.log('Creando Base de competencia...');
+    const { data: base, error: baseError } = await supabase
+      .from('Bases')
+      .insert({
+        ID_Assessment,
+        Numero_Base: 1,
+        Nombre_Base: 'Liderazgo y Pruebas',
+        Competencia_Base: 'Resolución de Conflictos',
+        Descripcion_Base: 'Base generada para testear a los grupos',
+        Comportamiento1_Base: 'Se comunica efectivamente',
+        Comportamiento2_Base: 'Asume la responsabilidad',
+        Comportamiento3_Base: 'Ayuda a sus compañeros'
+      })
+      .select()
+      .single();
+    if (baseError) throw baseError;
+
+    // 4. Crear 3 Grupos Assessment
+    console.log('Creando 3 Grupos de prueba...');
+    const gruposPayload = [1, 2, 3].map((num) => ({
+      ID_Assessment,
+      Nombre_GrupoAssessment: `Equipo Testing ${num}`,
+      Descripcion_GrupoAssessment: `Equipo automático de prueba ${num}`
+    }));
+
+    const { data: gruposAssessment, error: groupError } = await supabase
+      .from('GrupoAssessment')
+      .insert(gruposPayload)
+      .select();
+    if (groupError) throw groupError;
+
+    const grupoIds = gruposAssessment.map(g => g.ID_GrupoAssessment);
+
+    // 5. Crear Calificador y Registrador (Staff)
+    console.log('Creando Calificador y Registrador (Staff)...');
+    const passwordRaw = 'prueba123';
+    const passwordHash = await bcrypt.hash(passwordRaw, 10);
+
+    const suffix = Date.now();
+    const emailCalificador = `calificador_${suffix}@test.com`;
+    const emailRegistrador = `registrador_${suffix}@test.com`;
+
+    const staffPayload = [
+      {
+        ID_Assessment,
+        Correo_Staff: emailCalificador,
+        Contrasena_Staff: passwordHash,
+        Rol_Staff: 'calificador',
+        Active: true,
+        ID_Base: base.ID_Base, 
+        ID_GrupoAssessment: null
+      },
+      {
+        ID_Assessment,
+        Correo_Staff: emailRegistrador,
+        Contrasena_Staff: passwordHash,
+        Rol_Staff: 'registrador',
+        Active: true,
+        ID_Base: null, 
+        ID_GrupoAssessment: null
+      }
+    ];
+
+    const { error: staffError } = await supabase
+      .from('Staff')
+      .insert(staffPayload);
+    if (staffError) throw staffError;
+
+    // 6. Crear 9 Participantes (3 por grupo)
+    console.log('Añadiendo 9 Participantes (3 por cada equipo)...');
+    
+    const participantesPayload = [];
+    let participantCount = 1;
+
+    for (const grupoId of grupoIds) {
+      for (let i = 0; i < 3; i++) {
+        participantesPayload.push({
+          ID_Assessment,
+          ID_GrupoAssessment: grupoId,
+          Nombre_Participante: `Estudiante de Prueba ${participantCount}`,
+          Correo_Participante: `estudiante_test${participantCount}@dummy.com`,
+          Rol_Participante: 'Estudiante',
+          FotoUrl_Participante: '' 
+        });
+        participantCount++;
+      }
+    }
+
+    const { error: partError } = await supabase
+      .from('Participante')
+      .insert(participantesPayload);
+    if (partError) throw partError;
+
+    console.log('\n✅ ¡Datos creados exitosamente! Ya puedes probar tu aplicación.');
+    console.log('=========================================');
+    console.log('🔑 Credenciales del Calificador:');
+    console.log(`   Email:    ${emailCalificador}`);
+    console.log(`   Password: ${passwordRaw}`);
+    console.log('-----------------------------------------');
+    console.log('🔑 Credenciales del Registrador:');
+    console.log(`   Email:    ${emailRegistrador}`);
+    console.log(`   Password: ${passwordRaw}`);
+    console.log('=========================================');
+    console.log(`📌 Assessment ID: ${ID_Assessment}`);
+    console.log(`📌 Grupos Generados: 3 (con 3 integrantes c/u)`);
+    console.log('=========================================');
+
+  } catch (error: any) {
+    console.error('❌ Ocurrió un error al seedear la base de datos:', error.message);
+  } finally {
+    process.exit(0);
+  }
+}
+
+seedTestData();

--- a/src/app/admin/rotaciones/page.tsx
+++ b/src/app/admin/rotaciones/page.tsx
@@ -23,7 +23,7 @@ type StaffRow = {
 type GrupoItem = { id: number; nombre: string };
 
 export default function RotationsDashboard() {
-  const { isAdmin, isLoading: authLoading, logout, getAuthHeaders } = useAdminAuth();
+  const { isAdmin, isLoading: authLoading, logout } = useAdminAuth();
 
   const [staff, setStaff] = useState<StaffRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -42,7 +42,7 @@ export default function RotationsDashboard() {
       try {
         const res = await authFetch(
           "/api/assessment/list",
-          { headers: { ...getAuthHeaders() } },
+          {},
           () => logout()
         );
         if (!res.ok) throw new Error("Error al cargar assessments");
@@ -62,7 +62,7 @@ export default function RotationsDashboard() {
         const query = selectedAssessment ? `?assessmentId=${selectedAssessment}` : "";
         const res = await authFetch(
           `/api/dashboard/rotations${query}`,
-          { headers: { ...getAuthHeaders() } },
+          {},
           () => logout()
         );
         if (!res.ok) {
@@ -91,7 +91,7 @@ export default function RotationsDashboard() {
       try {
         const res = await authFetch(
           `/api/assessment/groups-active?assessmentId=${selectedAssessment}`,
-          { headers: { ...getAuthHeaders() } },
+          {},
           () => logout()
         );
         if (!res.ok) throw new Error("Error al cargar grupos");
@@ -126,7 +126,7 @@ export default function RotationsDashboard() {
         "/api/staff/update-rotation",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             staffId: editModal.id,
             grupoAssessmentId: editModal.grupoId,

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -28,6 +28,7 @@ export default function Login() {
         headers: {
           "Content-Type": "application/json",
         },
+        credentials: "include",
         body: JSON.stringify({ email, password }),
       });
 
@@ -37,26 +38,16 @@ export default function Login() {
 
       const data = await response.json();
       
-      // Guardar token si viene en la respuesta
-      if (data.token) {
-        localStorage.setItem("authToken", data.token);
-      }
-
-      if (data.role) {
-        localStorage.setItem("authRole", data.role);
-      }
-      
       if (data.role === "admin") {
         const isSuper = Boolean(data.superAdmin);
-        loginAsAdmin(data.token, isSuper);
+        loginAsAdmin(isSuper);
         router.push(isSuper ? "/k7v9x2q0m5p8n1t6z3r4w9y1" : "/admin");
       } else if (data.role === "registrador") {
         router.push("/register");
       } else if (data.role === "calificador") {
-        // Save grader-specific data
+        // Save grader-specific data (operational, not sensitive)
         saveData(data.ID_Grupo, data.ID_Calificador, data.ID_Base);
-        // Login as grader (this sets the graderAuth in localStorage)
-        loginAsGrader(data.token);
+        loginAsGrader();
         router.push(`/grader`);
       } else {
         router.push("/dashboard");

--- a/src/features/admin/bases/hooks/useBasesActions.test.ts
+++ b/src/features/admin/bases/hooks/useBasesActions.test.ts
@@ -23,7 +23,6 @@ vi.mock('@/hooks/useAdminAuth', () => ({
 
 describe('useBasesActions', () => {
   const mockLogout = vi.fn();
-  const mockGetAuthHeaders = vi.fn(() => ({ Authorization: 'Bearer token' }));
   const mockSetBases = vi.fn();
 
   const mockBases: Base[] = [
@@ -44,7 +43,6 @@ describe('useBasesActions', () => {
     vi.clearAllMocks();
     (useAdminAuth as vi.Mock).mockReturnValue({
       logout: mockLogout,
-      getAuthHeaders: mockGetAuthHeaders,
     });
     
     // Auto-mock window.confirm

--- a/src/features/admin/bases/hooks/useBasesActions.ts
+++ b/src/features/admin/bases/hooks/useBasesActions.ts
@@ -11,7 +11,7 @@ interface UseBasesActionsProps {
 }
 
 export const useBasesActions = ({ bases, setBases, selectedAssessment }: UseBasesActionsProps) => {
-  const { logout, getAuthHeaders } = useAdminAuth();
+  const { logout } = useAdminAuth();
 
   const [showModal, setShowModal] = useState(false);
   const [editingBase, setEditingBase] = useState<Base | null>(null);
@@ -70,7 +70,7 @@ export const useBasesActions = ({ bases, setBases, selectedAssessment }: UseBase
           '/api/base/update',
           {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               idBase: editingBase.ID_Base,
               nombre: formData.nombre,
@@ -105,7 +105,7 @@ export const useBasesActions = ({ bases, setBases, selectedAssessment }: UseBase
           '/api/base/create',
           {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               assessmentId: Number(selectedAssessment),
               numeroBase: Number(formData.numeroBase),
@@ -131,7 +131,7 @@ export const useBasesActions = ({ bases, setBases, selectedAssessment }: UseBase
         // Refresh bases
         const refreshResponse = await authFetch(
           `/api/base/list?assessmentId=${selectedAssessment}`,
-          { headers: { ...getAuthHeaders() } },
+          {},
           () => logout()
         );
         if (refreshResponse.ok) {
@@ -158,7 +158,7 @@ export const useBasesActions = ({ bases, setBases, selectedAssessment }: UseBase
         '/api/base/delete',
         {
           method: 'DELETE',
-          headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ idBase: baseId }),
         },
         () => logout()

--- a/src/features/admin/bases/hooks/useBasesData.test.ts
+++ b/src/features/admin/bases/hooks/useBasesData.test.ts
@@ -15,11 +15,13 @@ vi.mock('@/components/UI/Toast', () => ({
   }
 }));
 
-const mockPush = vi.fn();
+const { mockPush, mockRouter } = vi.hoisted(() => {
+  const pushFn = vi.fn();
+  return { mockPush: pushFn, mockRouter: { push: pushFn } };
+});
+
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
+  useRouter: () => mockRouter,
 }));
 
 import { useAdminAuth } from '@/hooks/useAdminAuth';
@@ -30,18 +32,16 @@ vi.mock('@/hooks/useAdminAuth', () => ({
 
 describe('useBasesData', () => {
   const mockLogout = vi.fn();
-  const mockGetAuthHeaders = vi.fn(() => ({ Authorization: 'Bearer token' }));
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   const setupHook = (isAdmin = true, authLoading = false) => {
-    (useAdminAuth as vi.Mock).mockReturnValue({
+    (useAdminAuth as any).mockReturnValue({
       isAdmin,
       isLoading: authLoading,
       logout: mockLogout,
-      getAuthHeaders: mockGetAuthHeaders,
     });
     
     return renderHook(() => useBasesData());
@@ -61,7 +61,7 @@ describe('useBasesData', () => {
 
   it('should fetch assessments on mount if auth is ready and user is admin', async () => {
     const mockAssessments = [{ id: 1, nombre: 'A1', activo: true }];
-    (authFetch as vi.Mock).mockResolvedValueOnce({
+    (authFetch as any).mockResolvedValueOnce({
       ok: true,
       status: 200,
       json: async () => mockAssessments
@@ -81,7 +81,7 @@ describe('useBasesData', () => {
   });
 
   it('should handle assessment fetch errors gracefully', async () => {
-    (authFetch as vi.Mock).mockResolvedValueOnce({
+    (authFetch as any).mockResolvedValueOnce({
       ok: false,
       status: 500,
       json: async () => ({ error: 'Error' })
@@ -97,7 +97,7 @@ describe('useBasesData', () => {
   });
 
   it('should redirect to login if authFetch returns 401', async () => {
-    (authFetch as vi.Mock).mockResolvedValueOnce({
+    (authFetch as any).mockResolvedValueOnce({
       ok: false,
       status: 401,
       json: async () => ({})
@@ -112,7 +112,7 @@ describe('useBasesData', () => {
 
   it('should fetch bases when an assessment is selected', async () => {
     // Initial fetch for assessments
-    (authFetch as vi.Mock).mockResolvedValueOnce({
+    (authFetch as any).mockResolvedValueOnce({
       ok: true,
       status: 200,
       json: async () => [{ id: 1, nombre: 'A1', activo: true }]
@@ -126,7 +126,7 @@ describe('useBasesData', () => {
     });
 
     const mockBases = [{ ID_Base: 10, Nombre_Base: 'Base 1' }];
-    (authFetch as vi.Mock).mockResolvedValueOnce({
+    (authFetch as any).mockResolvedValueOnce({
       ok: true,
       status: 200,
       json: async () => mockBases

--- a/src/features/admin/bases/hooks/useBasesData.ts
+++ b/src/features/admin/bases/hooks/useBasesData.ts
@@ -6,7 +6,7 @@ import { showToast } from '@/components/UI/Toast';
 import { type Assessment, type Base } from '../schemas/basesSchemas';
 
 export const useBasesData = () => {
-  const { isAdmin, isLoading: authLoading, logout, getAuthHeaders } = useAdminAuth();
+  const { isAdmin, isLoading: authLoading, logout } = useAdminAuth();
   const router = useRouter();
   
   const [assessments, setAssessments] = useState<Assessment[]>([]);
@@ -22,7 +22,7 @@ export const useBasesData = () => {
       try {
         const response = await authFetch(
           '/api/assessment/list',
-          { headers: { ...getAuthHeaders() } },
+          {},
           () => logout()
         );
 
@@ -41,7 +41,7 @@ export const useBasesData = () => {
     };
 
     fetchAssessments();
-  }, [authLoading, isAdmin, router, getAuthHeaders, logout]);
+  }, [authLoading, isAdmin, router, logout]);
 
   // Load bases when selected assessment changes
   useEffect(() => {
@@ -56,7 +56,7 @@ export const useBasesData = () => {
       try {
         const response = await authFetch(
           `/api/base/list?assessmentId=${selectedAssessment}`,
-          { headers: { ...getAuthHeaders() } },
+          {},
           () => logout()
         );
 
@@ -77,7 +77,7 @@ export const useBasesData = () => {
     };
 
     fetchBases();
-  }, [selectedAssessment, authLoading, isAdmin, router, getAuthHeaders, logout]);
+  }, [selectedAssessment, authLoading, isAdmin, router, logout]);
 
   return {
     assessments,

--- a/src/features/admin/configuracion/ConfigContainer.tsx
+++ b/src/features/admin/configuracion/ConfigContainer.tsx
@@ -30,15 +30,14 @@ export const ConfigContainer = () => {
     isSuperAdmin,
     isLoading: authLoading,
     logout,
-    getAuthHeaders,
   } = useAdminAuth();
   const router = useRouter();
 
   // Domain Hooks
-  const { data, setData, loading: dataLoading, error: dataError, fetchData } = useConfigData(getAuthHeaders, logout);
-  const { assessments, refreshAssessments } = useAssessments(getAuthHeaders, logout);
-  const { participants, groups, loadParticipantsAndGroups } = useParticipantsAndGroups(getAuthHeaders, logout);
-  const { basesList, loadBases } = useBases(getAuthHeaders, logout);
+  const { data, setData, loading: dataLoading, error: dataError, fetchData } = useConfigData(logout);
+  const { assessments, refreshAssessments } = useAssessments(logout);
+  const { participants, groups, loadParticipantsAndGroups } = useParticipantsAndGroups(logout);
+  const { basesList, loadBases } = useBases(logout);
 
   // UI State
   const [editModal, setEditModal] = useState<Calificacion | null>(null);
@@ -169,7 +168,7 @@ export const ConfigContainer = () => {
       '/api/update-person',
       {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updates),
       },
       () => logout()
@@ -198,7 +197,7 @@ export const ConfigContainer = () => {
         '/api/assessment/toggle-active',
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ assessmentId, activo: !activo }),
         },
         () => logout()
@@ -234,7 +233,7 @@ export const ConfigContainer = () => {
         '/api/staff/create',
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             assessmentId: Number(staffAssessmentId),
             correo: staffCorreo.trim(),
@@ -274,7 +273,7 @@ export const ConfigContainer = () => {
         '/api/participante/assign-group',
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             assessmentId: Number(configAssessmentId),
             participanteId: Number(selectedParticipant),
@@ -315,7 +314,7 @@ export const ConfigContainer = () => {
         '/api/assessment/auto-groups',
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             assessmentId: Number(configAssessmentId),
             numGroups,
@@ -351,7 +350,7 @@ export const ConfigContainer = () => {
         '/api/assessment/create',
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             grupoEstudiantilId: Number(grupoEstudiantilId),
             nombre: assessmentNombre.trim(),

--- a/src/features/admin/configuracion/hooks/useAssessments.test.ts
+++ b/src/features/admin/configuracion/hooks/useAssessments.test.ts
@@ -8,7 +8,6 @@ vi.mock('@/lib/auth/authFetch', () => ({
 }));
 
 describe('useAssessments', () => {
-  const getAuthHeaders = vi.fn().mockReturnValue({ Authorization: 'Bearer token' });
   const logout = vi.fn();
 
   beforeEach(() => {
@@ -16,7 +15,7 @@ describe('useAssessments', () => {
   });
 
   it('should initialize with empty assessments and not loading', () => {
-    const { result } = renderHook(() => useAssessments(getAuthHeaders, logout));
+    const { result } = renderHook(() => useAssessments(logout));
     
     expect(result.current.assessments).toEqual([]);
     expect(result.current.loading).toBe(false);
@@ -33,7 +32,7 @@ describe('useAssessments', () => {
       json: async () => mockData,
     } as Response);
 
-    const { result } = renderHook(() => useAssessments(getAuthHeaders, logout));
+    const { result } = renderHook(() => useAssessments(logout));
 
     await act(async () => {
       await result.current.refreshAssessments();
@@ -43,7 +42,7 @@ describe('useAssessments', () => {
     expect(result.current.assessments).toEqual(mockData);
     expect(authFetch).toHaveBeenCalledWith(
       '/api/assessment/list',
-      { headers: { Authorization: 'Bearer token' } },
+      {},
       expect.any(Function)
     );
   });
@@ -58,7 +57,7 @@ describe('useAssessments', () => {
       json: async () => invalidMockData,
     } as Response);
 
-    const { result } = renderHook(() => useAssessments(getAuthHeaders, logout));
+    const { result } = renderHook(() => useAssessments(logout));
 
     await act(async () => {
       await result.current.refreshAssessments();
@@ -73,7 +72,7 @@ describe('useAssessments', () => {
       ok: false,
     } as Response);
 
-    const { result } = renderHook(() => useAssessments(getAuthHeaders, logout));
+    const { result } = renderHook(() => useAssessments(logout));
 
     await act(async () => {
       await result.current.refreshAssessments();

--- a/src/features/admin/configuracion/hooks/useAssessments.ts
+++ b/src/features/admin/configuracion/hooks/useAssessments.ts
@@ -3,7 +3,7 @@ import { authFetch } from '@/lib/auth/authFetch';
 import { z } from 'zod';
 import { AssessmentSchema, type Assessment } from '../schemas/configSchemas';
 
-export function useAssessments(getAuthHeaders: () => any, logout: () => void) {
+export function useAssessments(logout: () => void) {
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [loading, setLoading] = useState(false);
 
@@ -12,7 +12,7 @@ export function useAssessments(getAuthHeaders: () => any, logout: () => void) {
     try {
       const response = await authFetch(
         '/api/assessment/list',
-        { headers: { ...getAuthHeaders() } },
+        {},
         () => logout()
       );
       if (!response.ok) throw new Error('Error al cargar assessments');
@@ -30,7 +30,7 @@ export function useAssessments(getAuthHeaders: () => any, logout: () => void) {
     } finally {
       setLoading(false);
     }
-  }, [getAuthHeaders, logout]);
+  }, [logout]);
 
   return { assessments, loading, refreshAssessments };
 }

--- a/src/features/admin/configuracion/hooks/useBases.ts
+++ b/src/features/admin/configuracion/hooks/useBases.ts
@@ -3,7 +3,7 @@ import { authFetch } from '@/lib/auth/authFetch';
 import { z } from 'zod';
 import { BaseSchema, type Base } from '../schemas/configSchemas';
 
-export function useBases(getAuthHeaders: () => any, logout: () => void) {
+export function useBases(logout: () => void) {
   const [basesList, setBasesList] = useState<Base[]>([]);
   const [loading, setLoading] = useState(false);
 
@@ -17,7 +17,7 @@ export function useBases(getAuthHeaders: () => any, logout: () => void) {
     try {
       const res = await authFetch(
         `/api/base/list?assessmentId=${assessmentId}`,
-        { headers: { ...getAuthHeaders() } },
+        {},
         () => logout()
       );
 
@@ -34,7 +34,7 @@ export function useBases(getAuthHeaders: () => any, logout: () => void) {
     } finally {
       setLoading(false);
     }
-  }, [getAuthHeaders, logout]);
+  }, [logout]);
 
   return { basesList, loading, loadBases };
 }

--- a/src/features/admin/configuracion/hooks/useConfigData.ts
+++ b/src/features/admin/configuracion/hooks/useConfigData.ts
@@ -4,7 +4,7 @@ import { showToast } from '@/components/UI/Toast';
 import { z } from 'zod';
 import { CalificacionSchema, type Calificacion } from '../schemas/configSchemas';
 
-export function useConfigData(getAuthHeaders: () => any, logout: () => void) {
+export function useConfigData(logout: () => void) {
   const [data, setData] = useState<Calificacion[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -26,7 +26,7 @@ export function useConfigData(getAuthHeaders: () => any, logout: () => void) {
 
       const response = await authFetch(
         url,
-        { headers: { ...getAuthHeaders() }, signal: controller.signal },
+        { signal: controller.signal },
         () => logout()
       );
 
@@ -61,7 +61,7 @@ export function useConfigData(getAuthHeaders: () => any, logout: () => void) {
         fetchAbortRef.current = null;
       }
     }
-  }, [getAuthHeaders, logout]);
+  }, [logout]);
 
   useEffect(() => {
     return () => {

--- a/src/features/admin/configuracion/hooks/useParticipantsAndGroups.ts
+++ b/src/features/admin/configuracion/hooks/useParticipantsAndGroups.ts
@@ -3,7 +3,7 @@ import { authFetch } from '@/lib/auth/authFetch';
 import { z } from 'zod';
 import { ParticipantSchema, GroupSchema, type Participant, type Group } from '../schemas/configSchemas';
 
-export function useParticipantsAndGroups(getAuthHeaders: () => any, logout: () => void) {
+export function useParticipantsAndGroups(logout: () => void) {
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [groups, setGroups] = useState<Group[]>([]);
   const [loading, setLoading] = useState(false);
@@ -20,12 +20,12 @@ export function useParticipantsAndGroups(getAuthHeaders: () => any, logout: () =
       const [participantsRes, groupsRes] = await Promise.all([
         authFetch(
           `/api/participante/list?assessmentId=${assessmentId}`,
-          { headers: { ...getAuthHeaders() } },
+          {},
           () => logout()
         ),
         authFetch(
           `/api/assessment/groups?assessmentId=${assessmentId}`,
-          { headers: { ...getAuthHeaders() } },
+          {},
           () => logout()
         ),
       ]);
@@ -46,7 +46,7 @@ export function useParticipantsAndGroups(getAuthHeaders: () => any, logout: () =
     } finally {
       setLoading(false);
     }
-  }, [getAuthHeaders, logout]);
+  }, [logout]);
 
   return { participants, groups, loading, loadParticipantsAndGroups };
 }

--- a/src/features/admin/gestion/GestionContainer.tsx
+++ b/src/features/admin/gestion/GestionContainer.tsx
@@ -29,13 +29,13 @@ import { type ParticipantDashboardRow } from "./schemas/gestionSchemas";
 import { showToast } from "@/components/UI/Toast";
 
 export const GestionContainer = () => {
-  const { isAdmin, isLoading: authLoading, logout, getAuthHeaders } = useAdminAuth();
+  const { isAdmin, isLoading: authLoading, logout } = useAdminAuth();
   const router = useRouter();
 
   // Domain Hooks
   const { classificationRanges, updateRanges } = useClassificationRanges();
-  const { assessments, refreshAssessments } = useAssessments(getAuthHeaders, logout);
-  const { data, setData, loading: dataLoading, error: dataError, fetchData } = useGestionData(getAuthHeaders, logout);
+  const { assessments, refreshAssessments } = useAssessments(logout);
+  const { data, setData, loading: dataLoading, error: dataError, fetchData } = useGestionData(logout);
 
   // UI State
   const [selectedAssessment, setSelectedAssessment] = useState<string>("");
@@ -50,7 +50,7 @@ export const GestionContainer = () => {
     handleUpdate,
     openEditModal,
     closeEditModal
-  } = useGestionActions(getAuthHeaders, logout, setData);
+  } = useGestionActions(logout, setData);
 
   // Filtering Hook
   const {

--- a/src/features/admin/gestion/hooks/useAssessments.ts
+++ b/src/features/admin/gestion/hooks/useAssessments.ts
@@ -3,7 +3,7 @@ import { authFetch } from '@/lib/auth/authFetch';
 import { z } from 'zod';
 import { AssessmentSchema, type Assessment } from '../schemas/gestionSchemas';
 
-export function useAssessments(getAuthHeaders: () => any, logout: () => void) {
+export function useAssessments(logout: () => void) {
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [loading, setLoading] = useState(false);
 
@@ -12,7 +12,7 @@ export function useAssessments(getAuthHeaders: () => any, logout: () => void) {
     try {
       const response = await authFetch(
         '/api/assessment/list',
-        { headers: { ...getAuthHeaders() } },
+        {},
         () => logout()
       );
       if (!response.ok) throw new Error('Error al cargar assessments');
@@ -30,7 +30,7 @@ export function useAssessments(getAuthHeaders: () => any, logout: () => void) {
     } finally {
       setLoading(false);
     }
-  }, [getAuthHeaders, logout]);
+  }, [logout]);
 
   return { assessments, loading, refreshAssessments };
 }

--- a/src/features/admin/gestion/hooks/useGestionActions.ts
+++ b/src/features/admin/gestion/hooks/useGestionActions.ts
@@ -4,7 +4,6 @@ import { showToast } from "@/components/UI/Toast";
 import { type ParticipantDashboardRow } from "../schemas/gestionSchemas";
 
 export function useGestionActions(
-  getAuthHeaders: () => any,
   logout: () => void,
   setData: React.Dispatch<React.SetStateAction<ParticipantDashboardRow[]>>
 ) {
@@ -28,7 +27,7 @@ export function useGestionActions(
     try {
       const res = await authFetch("/api/update-person", {
         method: "PUT",
-        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(updates),
       }, () => logout());
 

--- a/src/features/admin/gestion/hooks/useGestionData.ts
+++ b/src/features/admin/gestion/hooks/useGestionData.ts
@@ -3,7 +3,7 @@ import { authFetch } from '@/lib/auth/authFetch';
 import { z } from 'zod';
 import { ParticipantDashboardRowSchema, type ParticipantDashboardRow } from '../schemas/gestionSchemas';
 
-export function useGestionData(getAuthHeaders: () => any, logout: () => void) {
+export function useGestionData(logout: () => void) {
   const [data, setData] = useState<ParticipantDashboardRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +22,7 @@ export function useGestionData(getAuthHeaders: () => any, logout: () => void) {
       const query = assessmentId ? `?assessmentId=${assessmentId}` : "";
       const response = await authFetch(
         `/api/dashboard/gh${query}`,
-        { headers: { ...getAuthHeaders() }, signal: controller.signal },
+        { signal: controller.signal },
         () => logout()
       );
 
@@ -50,7 +50,7 @@ export function useGestionData(getAuthHeaders: () => any, logout: () => void) {
         setLoading(false);
       }
     }
-  }, [getAuthHeaders, logout]);
+  }, [logout]);
 
   useEffect(() => {
     return () => {

--- a/src/features/grader/hooks/useGraderActions.ts
+++ b/src/features/grader/hooks/useGraderActions.ts
@@ -46,13 +46,12 @@ export const useGraderActions = (
       if (!id_calificador || !id_base) return;
 
       try {
-        const authToken = localStorage.getItem("authToken");
-        const authHeaders: HeadersInit = authToken ? { Authorization: `Bearer ${authToken}` } : {};
-        const jsonHeaders: HeadersInit = { 'Content-Type': 'application/json', ...authHeaders };
+        const jsonHeaders: HeadersInit = { 'Content-Type': 'application/json' };
 
         const response = await fetch('/api/get-calificaciones-by-calificador', {
           method: 'POST',
           headers: jsonHeaders,
+          credentials: 'include',
           body: JSON.stringify({ idCalificador: id_calificador, idBase: id_base }),
         });
 
@@ -160,13 +159,12 @@ export const useGraderActions = (
     });
 
     try {
-      const authToken = localStorage.getItem("authToken");
-      const authHeaders: HeadersInit = authToken ? { Authorization: `Bearer ${authToken}` } : {};
-      const jsonHeaders: HeadersInit = { 'Content-Type': 'application/json', ...authHeaders };
+      const jsonHeaders: HeadersInit = { 'Content-Type': 'application/json' };
 
       const response = await fetch('/api/add-calificaciones', {
         method: 'POST',
         headers: jsonHeaders,
+        credentials: 'include',
         body: JSON.stringify({
           calificaciones: payload,
           idGrupo: selectedGroupId ? Number(selectedGroupId) : undefined,

--- a/src/features/grader/hooks/useGraderData.test.ts
+++ b/src/features/grader/hooks/useGraderData.test.ts
@@ -33,7 +33,6 @@ describe('useGraderData', () => {
 
     it('should fetch initial data successfully on mount', async () => {
         localStorage.setItem('storedData', JSON.stringify({ id_Calificador: 1, id_base: 10 }));
-        localStorage.setItem('authToken', 'fake_token');
 
         const mockGroups = [{ id: 100, nombre: 'Group A' }];
         const mockBase = { id: 10, nombre: 'Base 1' };

--- a/src/features/grader/hooks/useGraderData.ts
+++ b/src/features/grader/hooks/useGraderData.ts
@@ -17,9 +17,7 @@ export const useGraderData = () => {
     const storedData = localStorage.getItem("storedData");
     const parsedData = storedData ? JSON.parse(storedData) : null;
     const id_Calificador = parsedData?.id_Calificador;
-    const authToken = localStorage.getItem("authToken");
-    const authHeaders: HeadersInit = authToken ? { Authorization: `Bearer ${authToken}` } : {};
-    const jsonHeaders: HeadersInit = { 'Content-Type': 'application/json', ...authHeaders };
+    const jsonHeaders: HeadersInit = { 'Content-Type': 'application/json' };
 
     if (!id_Calificador) {
       setLoading(false);
@@ -33,16 +31,19 @@ export const useGraderData = () => {
           fetch('/api/grader/groups', {
             method: 'POST',
             headers: jsonHeaders,
+            credentials: 'include',
             body: JSON.stringify({ idCalificador: id_Calificador, idBase: idBase ?? undefined }),
           }),
           idBase ? fetch('/api/getBaseData', {
             method: 'POST',
             headers: jsonHeaders,
+            credentials: 'include',
             body: JSON.stringify({ id_base: idBase }),
           }) : Promise.resolve(null),
           fetch('/api/getCalificador', {
             method: 'POST',
             headers: jsonHeaders,
+            credentials: 'include',
             body: JSON.stringify({ id_calificador: id_Calificador }),
           })
         ]);
@@ -79,10 +80,7 @@ export const useGraderData = () => {
     const parsedData = storedData ? JSON.parse(storedData) : null;
     const id_Calificador = parsedData?.id_Calificador;
     const idBase = parsedData?.id_base;
-    const authToken = localStorage.getItem("authToken");
-    const jsonHeaders: HeadersInit = authToken
-      ? { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` }
-      : { 'Content-Type': 'application/json' };
+    const jsonHeaders: HeadersInit = { 'Content-Type': 'application/json' };
 
     if (!selectedGroupId || !id_Calificador || !idBase) {
       setUsuarios([]);
@@ -98,11 +96,13 @@ export const useGraderData = () => {
           fetch('/api/grader/participants', {
             method: 'POST',
             headers: jsonHeaders,
+            credentials: 'include',
             body: JSON.stringify({ idCalificador: id_Calificador, idGrupo: Number(selectedGroupId) }),
           }),
           fetch('/api/check-already-graded', {
             method: 'POST',
             headers: jsonHeaders,
+            credentials: 'include',
             body: JSON.stringify({
               idCalificador: id_Calificador,
               idBase,

--- a/src/features/register/hooks/useRegisterAuth.test.ts
+++ b/src/features/register/hooks/useRegisterAuth.test.ts
@@ -12,10 +12,10 @@ vi.mock('next/navigation', () => ({
 describe('useRegisterAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
   });
 
-  it('should redirect to login when no token exists', async () => {
+  it('should redirect to login when fetch fails (not authorized)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
     const { result } = renderHook(() => useRegisterAuth());
 
     await waitFor(() => {
@@ -25,8 +25,10 @@ describe('useRegisterAuth', () => {
   });
 
   it('should redirect to login when role is invalid', async () => {
-    localStorage.setItem('authToken', 'valid-token');
-    localStorage.setItem('authRole', 'calificador');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
+      ok: true, 
+      json: async () => ({ role: 'calificador' }) 
+    }));
 
     renderHook(() => useRegisterAuth());
 
@@ -36,8 +38,10 @@ describe('useRegisterAuth', () => {
   });
 
   it('should stop checking auth for registrador role', async () => {
-    localStorage.setItem('authToken', 'valid-token');
-    localStorage.setItem('authRole', 'registrador');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
+      ok: true, 
+      json: async () => ({ role: 'registrador' }) 
+    }));
 
     const { result } = renderHook(() => useRegisterAuth());
 
@@ -48,8 +52,10 @@ describe('useRegisterAuth', () => {
   });
 
   it('should stop checking auth for admin role', async () => {
-    localStorage.setItem('authToken', 'valid-token');
-    localStorage.setItem('authRole', 'admin');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
+      ok: true, 
+      json: async () => ({ role: 'admin' }) 
+    }));
 
     const { result } = renderHook(() => useRegisterAuth());
 

--- a/src/features/register/hooks/useRegisterAuth.ts
+++ b/src/features/register/hooks/useRegisterAuth.ts
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation';
 
 /**
  * Auth guard for the register page.
- * Checks localStorage for token + role (registrador | admin).
+ * Validates session via /api/auth/me cookie-based endpoint.
  * Redirects to /auth/login if not authorized.
  */
 export const useRegisterAuth = () => {
@@ -11,15 +11,23 @@ export const useRegisterAuth = () => {
   const [checkingAuth, setCheckingAuth] = useState(true);
 
   useEffect(() => {
-    const token = localStorage.getItem('authToken');
-    const role = localStorage.getItem('authRole');
-
-    if (!token || (role !== 'registrador' && role !== 'admin')) {
+    const checkAuth = async () => {
+      try {
+        const res = await fetch('/api/auth/me', { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.role === 'registrador' || data.role === 'admin') {
+            setCheckingAuth(false);
+            return;
+          }
+        }
+      } catch {
+        // Auth check failed
+      }
       router.push('/auth/login');
-      return;
-    }
+    };
 
-    setCheckingAuth(false);
+    checkAuth();
   }, [router]);
 
   return { checkingAuth };

--- a/src/features/register/hooks/useRegisterForm.ts
+++ b/src/features/register/hooks/useRegisterForm.ts
@@ -49,12 +49,9 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
   }, [photo]);
 
   const handleImageSelect = async (file: File) => {
-    // Revoke previous URL to prevent memory leaks
-    if (photo) {
-      URL.revokeObjectURL(photo);
-    }
+    const tempUrl = URL.createObjectURL(file);
     setFileName(file.name);
-    setPhoto(URL.createObjectURL(file));
+    setPhoto(tempUrl);
 
     const result = await compressImage(file);
     if (isCompressError(result)) {
@@ -62,11 +59,8 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
       setIsError(true);
       setImagen(null);
       setFileName('');
-      // Clean up the URL we just created since we're discarding the file
-      if (photo) {
-        URL.revokeObjectURL(photo);
-      }
       setPhoto('');
+      URL.revokeObjectURL(tempUrl);
       if (fileInputRef.current) fileInputRef.current.value = '';
       return;
     }
@@ -95,11 +89,9 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
         formData.append('image', imagen);
       }
 
-      const token = localStorage.getItem('authToken');
-
       const response = await fetch('/api/register', {
         method: 'POST',
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        credentials: 'include',
         body: formData,
       });
 
@@ -126,9 +118,6 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
     setNombre('');
     setCorreo('');
     setImagen(null);
-    if (photo) {
-      URL.revokeObjectURL(photo);
-    }
     setPhoto('');
     setFileName('');
     setMensaje('');

--- a/src/features/super-admin/SuperAdminContainer.tsx
+++ b/src/features/super-admin/SuperAdminContainer.tsx
@@ -21,7 +21,7 @@ import { Pagination } from "@/features/admin/gestion/components/Pagination"; // 
 import { handleExportAdminsCSV } from "./utils/superAdminUtils";
 
 export const SuperAdminContainer = () => {
-  const { isSuperAdmin, isLoading: authLoading, logout, getAuthHeaders, requireSuperAdmin } = useSuperAdminAuth();
+  const { isSuperAdmin, isLoading: authLoading, logout, requireSuperAdmin } = useSuperAdminAuth();
   
   // Data Hook
   const {
@@ -37,7 +37,7 @@ export const SuperAdminContainer = () => {
     loading: dataLoading,
     error: dataError,
     fetchData
-  } = useSuperAdminData(getAuthHeaders, logout);
+  } = useSuperAdminData(logout);
 
   // Filters Hook
   const {
@@ -71,7 +71,6 @@ export const SuperAdminContainer = () => {
     handleUpdateAssessment,
     handleUpdateAdmin
   } = useSuperAdminActions(
-    getAuthHeaders, 
     logout, 
     gruposEstudiantiles, 
     assessments, 

--- a/src/features/super-admin/hooks/useSuperAdminActions.ts
+++ b/src/features/super-admin/hooks/useSuperAdminActions.ts
@@ -10,7 +10,6 @@ import {
 import { getBulkAssessmentPayloads, getBulkAdminPayloads } from '../utils/superAdminUtils';
 
 export function useSuperAdminActions(
-  getAuthHeaders: () => any,
   logout: () => void,
   gruposEstudiantiles: GrupoEstudiantil[],
   assessments: Assessment[],
@@ -39,7 +38,7 @@ export function useSuperAdminActions(
         "/api/assessment/bulk-create",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             grupoIds: payloads.map((item) => item.grupoEstudiantilId),
             activo: assessmentActivo,
@@ -94,7 +93,7 @@ export function useSuperAdminActions(
         "/api/staff/bulk-create-admins",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ assessmentIds: payloads.map((item) => item.assessment.id) }),
         },
         () => logout()
@@ -145,7 +144,7 @@ export function useSuperAdminActions(
         "/api/assessment/update",
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             id: assessmentId,
             descripcion: edit.descripcion,
@@ -183,7 +182,7 @@ export function useSuperAdminActions(
         "/api/staff/update",
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             id: adminId,
             correo: edit.correo,

--- a/src/features/super-admin/hooks/useSuperAdminData.ts
+++ b/src/features/super-admin/hooks/useSuperAdminData.ts
@@ -7,7 +7,7 @@ import {
   type AdminUser 
 } from '../schemas/superAdminSchemas';
 
-export function useSuperAdminData(getAuthHeaders: () => any, logout: () => void) {
+export function useSuperAdminData(logout: () => void) {
   const [gruposEstudiantiles, setGruposEstudiantiles] = useState<GrupoEstudiantil[]>([]);
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [admins, setAdmins] = useState<AdminUser[]>([]);
@@ -35,7 +35,7 @@ export function useSuperAdminData(getAuthHeaders: () => any, logout: () => void)
     try {
       const response = await authFetch(
         "/api/admin/panel-data",
-        { headers: { ...getAuthHeaders() }, signal: controller.signal },
+        { signal: controller.signal },
         () => logout()
       );
 
@@ -81,7 +81,7 @@ export function useSuperAdminData(getAuthHeaders: () => any, logout: () => void)
         setLoading(false);
       }
     }
-  }, [getAuthHeaders, logout]);
+  }, [logout]);
 
   useEffect(() => {
     return () => {

--- a/src/hooks/useAdminAuth.ts
+++ b/src/hooks/useAdminAuth.ts
@@ -1,49 +1,57 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 
-const ADMIN_KEY = "adminAuth";
-const TOKEN_KEY = "authToken";
-
 interface AdminAuth {
   isAdmin: boolean;
   isSuperAdmin?: boolean;
   timestamp: number;
-  token?: string;
 }
 
-// Tiempo de expiración de la sesión (8 horas en ms)
+const ADMIN_KEY = "adminAuth";
+
+// Session duration (8 hours in ms) — only for local state expiry
 const SESSION_DURATION = 8 * 60 * 60 * 1000;
 
 export const useAdminAuth = () => {
-  const [isAdmin, setIsAdmin] = useState<boolean | null>(null); // null = cargando
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null); // null = loading
   const [isSuperAdmin, setIsSuperAdmin] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [token, setToken] = useState<string | null>(null);
   const router = useRouter();
 
   useEffect(() => {
-    const checkAuth = () => {
-      const savedAuth = localStorage.getItem(ADMIN_KEY);
-      const savedToken = localStorage.getItem(TOKEN_KEY);
-
-      if (savedAuth) {
-        const authData: AdminAuth = JSON.parse(savedAuth);
-        const now = Date.now();
-
-        // Verificar si la sesión no ha expirado
-        if (authData.isAdmin && now - authData.timestamp < SESSION_DURATION) {
-          setIsAdmin(true);
-          setIsSuperAdmin(Boolean(authData.isSuperAdmin));
-          setToken(savedToken);
-        } else {
-          // Sesión expirada, limpiar
+    const checkAuth = async () => {
+      try {
+        // Check local state first (for role/superAdmin info)
+        const savedAuth = localStorage.getItem(ADMIN_KEY);
+        if (savedAuth) {
+          const authData: AdminAuth = JSON.parse(savedAuth);
+          const now = Date.now();
+          if (authData.isAdmin && now - authData.timestamp < SESSION_DURATION) {
+            setIsAdmin(true);
+            setIsSuperAdmin(Boolean(authData.isSuperAdmin));
+            setIsLoading(false);
+            return;
+          }
+          // Expired local state, clear it
           localStorage.removeItem(ADMIN_KEY);
-          localStorage.removeItem(TOKEN_KEY);
+        }
+
+        // Validate session via cookie-based endpoint
+        const res = await fetch("/api/auth/me", { credentials: "include" });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.role === "admin") {
+            setIsAdmin(true);
+            // Note: superAdmin info isn't in JWT, so we check localStorage
+            setIsSuperAdmin(Boolean(savedAuth && JSON.parse(savedAuth).isSuperAdmin));
+          } else {
+            setIsAdmin(false);
+          }
+        } else {
           setIsAdmin(false);
           setIsSuperAdmin(false);
-          setToken(null);
         }
-      } else {
+      } catch {
         setIsAdmin(false);
         setIsSuperAdmin(false);
       }
@@ -53,44 +61,37 @@ export const useAdminAuth = () => {
     checkAuth();
   }, []);
 
-  // Función para establecer admin auth (llamar después de login exitoso)
-  const loginAsAdmin = useCallback((authToken?: string, superAdmin = false) => {
+  // Set admin auth after login — only stores role info locally, NOT the token
+  const loginAsAdmin = useCallback((superAdmin = false) => {
     const authData: AdminAuth = {
       isAdmin: true,
       isSuperAdmin: superAdmin,
       timestamp: Date.now(),
     };
     localStorage.setItem(ADMIN_KEY, JSON.stringify(authData));
-    if (authToken) {
-      localStorage.setItem(TOKEN_KEY, authToken);
-      setToken(authToken);
-    }
     setIsAdmin(true);
     setIsSuperAdmin(superAdmin);
   }, []);
 
-  // Función para cerrar sesión
-  const logout = useCallback(() => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
-    if (storedToken) {
-      fetch("/api/auth/logout", {
+  // Logout — server clears cookies
+  const logout = useCallback(async () => {
+    try {
+      await fetch("/api/auth/logout", {
         method: "POST",
-        headers: { Authorization: `Bearer ${storedToken}` },
-      }).catch(() => {
-        // No-op: logout local continúa aunque falle el request.
+        credentials: "include",
       });
+    } catch {
+      // No-op: local logout continues even if request fails
     }
     localStorage.removeItem(ADMIN_KEY);
-    localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem("storedData");
     localStorage.removeItem("authRole");
     setIsAdmin(false);
     setIsSuperAdmin(false);
-    setToken(null);
     router.push("/auth/login");
   }, [router]);
 
-  // Función para proteger rutas - redirige si no es admin
+  // Route protection
   const requireAdmin = useCallback(() => {
     if (!isLoading && !isAdmin) {
       router.push("/auth/login");
@@ -103,27 +104,13 @@ export const useAdminAuth = () => {
     }
   }, [isLoading, isSuperAdmin, router]);
 
-  // Función para obtener headers con token de autenticación
-  const getAuthHeaders = useCallback((): HeadersInit => {
-    if (token) {
-      return { Authorization: `Bearer ${token}` };
-    }
-    if (typeof window !== "undefined") {
-      const storedToken = localStorage.getItem(TOKEN_KEY);
-      return storedToken ? { Authorization: `Bearer ${storedToken}` } : {};
-    }
-    return {};
-  }, [token]);
-
   return {
     isAdmin,
     isSuperAdmin,
     isLoading,
-    token,
     loginAsAdmin,
     logout,
     requireAdmin,
     requireSuperAdmin,
-    getAuthHeaders,
   };
 };

--- a/src/hooks/useGraderAuth.ts
+++ b/src/hooks/useGraderAuth.ts
@@ -2,44 +2,45 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 
 const GRADER_KEY = "graderAuth";
-const TOKEN_KEY = "authToken";
 
 interface GraderAuth {
   isGrader: boolean;
   timestamp: number;
-  token?: string;
 }
 
-// Session expiration time (8 hours in ms)
+// Session duration (8 hours in ms) — only for local state expiry
 const SESSION_DURATION = 8 * 60 * 60 * 1000;
 
 export const useGraderAuth = () => {
   const [isGrader, setIsGrader] = useState<boolean | null>(null); // null = loading
   const [isLoading, setIsLoading] = useState(true);
-  const [token, setToken] = useState<string | null>(null);
   const router = useRouter();
 
   useEffect(() => {
-    const checkAuth = () => {
-      const savedAuth = localStorage.getItem(GRADER_KEY);
-      const savedToken = localStorage.getItem(TOKEN_KEY);
-
-      if (savedAuth) {
-        const authData: GraderAuth = JSON.parse(savedAuth);
-        const now = Date.now();
-
-        // Check if session hasn't expired
-        if (authData.isGrader && now - authData.timestamp < SESSION_DURATION) {
-          setIsGrader(true);
-          setToken(savedToken);
-        } else {
-          // Session expired, clean up
+    const checkAuth = async () => {
+      try {
+        // Check local state first
+        const savedAuth = localStorage.getItem(GRADER_KEY);
+        if (savedAuth) {
+          const authData: GraderAuth = JSON.parse(savedAuth);
+          const now = Date.now();
+          if (authData.isGrader && now - authData.timestamp < SESSION_DURATION) {
+            setIsGrader(true);
+            setIsLoading(false);
+            return;
+          }
           localStorage.removeItem(GRADER_KEY);
-          localStorage.removeItem(TOKEN_KEY);
-          setIsGrader(false);
-          setToken(null);
         }
-      } else {
+
+        // Validate session via cookie
+        const res = await fetch("/api/auth/me", { credentials: "include" });
+        if (res.ok) {
+          const data = await res.json();
+          setIsGrader(data.role === "calificador");
+        } else {
+          setIsGrader(false);
+        }
+      } catch {
         setIsGrader(false);
       }
       setIsLoading(false);
@@ -48,49 +49,39 @@ export const useGraderAuth = () => {
     checkAuth();
   }, []);
 
-  // Function to set grader auth (call after successful login)
-  const loginAsGrader = (authToken?: string) => {
+  // Set grader auth after login — only stores role info locally, NOT the token
+  const loginAsGrader = () => {
     const authData: GraderAuth = {
       isGrader: true,
       timestamp: Date.now(),
     };
     localStorage.setItem(GRADER_KEY, JSON.stringify(authData));
-    if (authToken) {
-      localStorage.setItem(TOKEN_KEY, authToken);
-      setToken(authToken);
-    }
     setIsGrader(true);
   };
 
-  // Function to logout
-  const logout = () => {
+  // Logout — server clears cookies
+  const logout = async () => {
+    try {
+      await fetch("/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch {
+      // No-op
+    }
     localStorage.removeItem(GRADER_KEY);
-    localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem("storedData");
     localStorage.removeItem("authRole");
     setIsGrader(false);
-    setToken(null);
     router.push("/auth/login");
   };
 
-  // Function to protect routes - redirects if not grader
+  // Route protection
   const requireGrader = () => {
     if (!isLoading && !isGrader) {
       router.push("/auth/login");
     }
   };
 
-  // Function to get headers with auth token
-  const getAuthHeaders = (): HeadersInit => {
-    if (token) {
-      return { Authorization: `Bearer ${token}` };
-    }
-    if (typeof window !== "undefined") {
-      const storedToken = localStorage.getItem(TOKEN_KEY);
-      return storedToken ? { Authorization: `Bearer ${storedToken}` } : {};
-    }
-    return {};
-  };
-
-  return { isGrader, isLoading, token, loginAsGrader, logout, requireGrader, getAuthHeaders };
+  return { isGrader, isLoading, loginAsGrader, logout, requireGrader };
 };

--- a/src/hooks/useSuperAdminAuth.test.ts
+++ b/src/hooks/useSuperAdminAuth.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useSuperAdminAuth } from './useSuperAdminAuth';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useRouter } from 'next/navigation';
@@ -14,44 +14,51 @@ describe('useSuperAdminAuth', () => {
     vi.clearAllMocks();
     vi.mocked(useRouter).mockReturnValue({ push: mockPush } as any);
     localStorage.clear();
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    // Default mock: not super admin
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
+      ok: true, 
+      json: async () => ({ role: 'not-admin' }) 
+    }));
   });
 
-  it('should initialize as not super admin if localStorage is empty', () => {
+  it('should initialize as not super admin if localStorage is empty', async () => {
     const { result } = renderHook(() => useSuperAdminAuth());
-    expect(result.current.isSuperAdmin).toBe(false);
-    expect(result.current.isLoading).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isSuperAdmin).toBe(false);
+      expect(result.current.isLoading).toBe(false);
+    });
   });
 
-  it('should identify super admin from localStorage if valid and not expired', () => {
+  it('should identify super admin from localStorage if valid and not expired', async () => {
     const validAuth = {
       isAdmin: true,
       isSuperAdmin: true,
       timestamp: Date.now()
     };
     localStorage.setItem('adminAuth', JSON.stringify(validAuth));
-    localStorage.setItem('authToken', 'test-token');
 
     const { result } = renderHook(() => useSuperAdminAuth());
     
-    expect(result.current.isSuperAdmin).toBe(true);
-    expect(result.current.token).toBe('test-token');
+    await waitFor(() => {
+      expect(result.current.isSuperAdmin).toBe(true);
+    });
   });
 
-  it('should identify as NOT super admin if isSuperAdmin flag is missing', () => {
+  it('should identify as NOT super admin if isSuperAdmin flag is missing', async () => {
     const invalidAuth = {
       isAdmin: true,
-      // isSuperAdmin: true, // Missing
       timestamp: Date.now()
     };
     localStorage.setItem('adminAuth', JSON.stringify(invalidAuth));
 
     const { result } = renderHook(() => useSuperAdminAuth());
     
-    expect(result.current.isSuperAdmin).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isSuperAdmin).toBe(false);
+    });
   });
 
-  it('should identify as NOT super admin if session expired', () => {
+  it('should identify as NOT super admin if session expired', async () => {
     const expiredAuth = {
       isAdmin: true,
       isSuperAdmin: true,
@@ -61,12 +68,18 @@ describe('useSuperAdminAuth', () => {
 
     const { result } = renderHook(() => useSuperAdminAuth());
     
-    expect(result.current.isSuperAdmin).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isSuperAdmin).toBe(false);
+    });
   });
 
-  it('requireSuperAdmin should redirect if not authorized', () => {
+  it('requireSuperAdmin should redirect if not authorized', async () => {
     const { result } = renderHook(() => useSuperAdminAuth());
     
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
     act(() => {
       result.current.requireSuperAdmin();
     });
@@ -75,14 +88,14 @@ describe('useSuperAdminAuth', () => {
   });
 
   it('logout should clear storage and redirect', async () => {
-    localStorage.setItem('authToken', 'token');
+    localStorage.setItem('adminAuth', JSON.stringify({ isAdmin: true, isSuperAdmin: true, timestamp: Date.now() }));
     const { result } = renderHook(() => useSuperAdminAuth());
 
     await act(async () => {
       result.current.logout();
     });
 
-    expect(localStorage.getItem('authToken')).toBeNull();
+    expect(localStorage.getItem('adminAuth')).toBeNull();
     expect(mockPush).toHaveBeenCalledWith('/auth/login');
   });
 });

--- a/src/hooks/useSuperAdminAuth.ts
+++ b/src/hooks/useSuperAdminAuth.ts
@@ -2,13 +2,11 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 
 const ADMIN_KEY = "adminAuth";
-const TOKEN_KEY = "authToken";
 
 interface AdminAuth {
   isAdmin: boolean;
   isSuperAdmin?: boolean;
   timestamp: number;
-  token?: string;
 }
 
 const SESSION_DURATION = 8 * 60 * 60 * 1000;
@@ -20,32 +18,44 @@ const SESSION_DURATION = 8 * 60 * 60 * 1000;
 export const useSuperAdminAuth = () => {
   const [isSuperAdmin, setIsSuperAdmin] = useState<boolean | null>(null); // null = loading
   const [isLoading, setIsLoading] = useState(true);
-  const [token, setToken] = useState<string | null>(null);
   const router = useRouter();
 
   useEffect(() => {
-    const checkAuth = () => {
+    const checkAuth = async () => {
+      // Check local state first (for superAdmin flag)
       const savedAuth = localStorage.getItem(ADMIN_KEY);
-      const savedToken = localStorage.getItem(TOKEN_KEY);
 
       if (savedAuth) {
         try {
           const authData: AdminAuth = JSON.parse(savedAuth);
           const now = Date.now();
 
-          // Only valid if isAdmin is true AND isSuperAdmin is true AND not expired
           if (authData.isAdmin && authData.isSuperAdmin && (now - authData.timestamp < SESSION_DURATION)) {
             setIsSuperAdmin(true);
-            setToken(savedToken);
-          } else {
-            setIsSuperAdmin(false);
-            setToken(null);
+            setIsLoading(false);
+            return;
           }
         } catch (e) {
           console.error("Failed to parse adminAuth", e);
+        }
+      }
+
+      // Validate session via cookie
+      try {
+        const res = await fetch("/api/auth/me", { credentials: "include" });
+        if (res.ok) {
+          const data = await res.json();
+          // /api/auth/me returns role=admin, but we need localStorage for isSuperAdmin flag
+          if (data.role === "admin" && savedAuth) {
+            const authData: AdminAuth = JSON.parse(savedAuth);
+            setIsSuperAdmin(Boolean(authData.isSuperAdmin));
+          } else {
+            setIsSuperAdmin(false);
+          }
+        } else {
           setIsSuperAdmin(false);
         }
-      } else {
+      } catch {
         setIsSuperAdmin(false);
       }
       setIsLoading(false);
@@ -54,20 +64,19 @@ export const useSuperAdminAuth = () => {
     checkAuth();
   }, []);
 
-  const logout = useCallback(() => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
-    if (storedToken) {
-      fetch("/api/auth/logout", {
+  const logout = useCallback(async () => {
+    try {
+      await fetch("/api/auth/logout", {
         method: "POST",
-        headers: { Authorization: `Bearer ${storedToken}` },
-      }).catch(() => {});
+        credentials: "include",
+      });
+    } catch {
+      // No-op
     }
     localStorage.removeItem(ADMIN_KEY);
-    localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem("storedData");
     localStorage.removeItem("authRole");
     setIsSuperAdmin(false);
-    setToken(null);
     router.push("/auth/login");
   }, [router]);
 
@@ -77,17 +86,10 @@ export const useSuperAdminAuth = () => {
     }
   }, [isLoading, isSuperAdmin, router]);
 
-  const getAuthHeaders = useCallback((): HeadersInit => {
-    const activeToken = token || (typeof window !== "undefined" ? localStorage.getItem(TOKEN_KEY) : null);
-    return activeToken ? { Authorization: `Bearer ${activeToken}` } : {};
-  }, [token]);
-
   return {
     isSuperAdmin,
     isLoading,
-    token,
     logout,
     requireSuperAdmin,
-    getAuthHeaders,
   };
 };

--- a/src/lib/auth/apiAuth.ts
+++ b/src/lib/auth/apiAuth.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { verifyToken, type TokenPayload } from '@/lib/auth';
+import { COOKIE_NAME } from '@/lib/auth/cookie';
 
 type Role = TokenPayload['role'];
 
@@ -8,8 +9,14 @@ export function requireRoles(
   res: NextApiResponse,
   allowed: Role[]
 ): TokenPayload | null {
-  const authHeader = req.headers.authorization;
-  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  // Read token from cookie first, fall back to Authorization header
+  let token: string | null = req.cookies?.[COOKIE_NAME] ?? null;
+
+  if (!token) {
+    const authHeader = req.headers.authorization;
+    token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  }
+
   const decoded = token ? verifyToken(token) : null;
 
   if (!decoded || !allowed.includes(decoded.role)) {

--- a/src/lib/auth/authFetch.ts
+++ b/src/lib/auth/authFetch.ts
@@ -3,7 +3,10 @@ export async function authFetch(
   init: RequestInit = {},
   onUnauthorized?: () => void
 ): Promise<Response> {
-  const res = await fetch(input, init);
+  const res = await fetch(input, {
+    ...init,
+    credentials: 'include', // Send cookies automatically
+  });
 
   if (res.status === 401) {
     if (onUnauthorized) {

--- a/src/lib/auth/cookie.test.ts
+++ b/src/lib/auth/cookie.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { setSessionCookie, clearSessionCookie } from './cookie';
+import type { NextApiResponse } from 'next';
+
+function createMockRes() {
+  return {
+    setHeader: vi.fn(),
+  } as unknown as NextApiResponse;
+}
+
+describe('setSessionCookie', () => {
+  it('should set session and role cookies with correct flags', () => {
+    const res = createMockRes();
+    setSessionCookie(res, 'jwt-token-123', 'admin');
+
+    expect(res.setHeader).toHaveBeenCalledTimes(1);
+    const [headerName, cookies] = (res.setHeader as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(headerName).toBe('Set-Cookie');
+    expect(cookies).toHaveLength(2);
+
+    // Session cookie: HttpOnly, token value
+    const sessionCookie = cookies[0] as string;
+    expect(sessionCookie).toContain('session=jwt-token-123');
+    expect(sessionCookie).toContain('HttpOnly');
+    expect(sessionCookie).toContain('SameSite=Lax');
+    expect(sessionCookie).toContain('Path=/');
+    expect(sessionCookie).toContain('Max-Age=28800');
+
+    // Role cookie: NOT HttpOnly
+    const roleCookie = cookies[1] as string;
+    expect(roleCookie).toContain('authRole=admin');
+    expect(roleCookie).not.toContain('HttpOnly');
+    expect(roleCookie).toContain('SameSite=Lax');
+  });
+
+  it('should set Secure flag in production', () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    const res = createMockRes();
+    setSessionCookie(res, 'token', 'calificador');
+
+    const [, cookies] = (res.setHeader as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((cookies[0] as string)).toContain('Secure');
+    expect((cookies[1] as string)).toContain('Secure');
+
+    process.env.NODE_ENV = originalEnv;
+  });
+});
+
+describe('clearSessionCookie', () => {
+  it('should set cookies with Max-Age=0 and empty value', () => {
+    const res = createMockRes();
+    clearSessionCookie(res);
+
+    expect(res.setHeader).toHaveBeenCalledTimes(1);
+    const [, cookies] = (res.setHeader as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(cookies).toHaveLength(2);
+
+    const sessionCookie = cookies[0] as string;
+    expect(sessionCookie).toContain('session=');
+    expect(sessionCookie).toContain('Max-Age=0');
+
+    const roleCookie = cookies[1] as string;
+    expect(roleCookie).toContain('authRole=');
+    expect(roleCookie).toContain('Max-Age=0');
+  });
+});

--- a/src/lib/auth/cookie.ts
+++ b/src/lib/auth/cookie.ts
@@ -1,0 +1,62 @@
+import type { NextApiResponse } from 'next';
+import { serialize } from 'cookie';
+
+const COOKIE_NAME = 'session';
+const ROLE_COOKIE_NAME = 'authRole';
+
+// 8 hours in seconds
+const MAX_AGE = 8 * 60 * 60;
+
+/**
+ * Set the session cookie (HttpOnly) and role cookie (readable by client).
+ */
+export function setSessionCookie(
+  res: NextApiResponse,
+  token: string,
+  role: string
+): void {
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  const sessionCookie = serialize(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: MAX_AGE,
+  });
+
+  const roleCookie = serialize(ROLE_COOKIE_NAME, role, {
+    httpOnly: false, // Client needs to read role for routing
+    secure: isProduction,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: MAX_AGE,
+  });
+
+  res.setHeader('Set-Cookie', [sessionCookie, roleCookie]);
+}
+
+/**
+ * Clear both session and role cookies.
+ */
+export function clearSessionCookie(res: NextApiResponse): void {
+  const sessionCookie = serialize(COOKIE_NAME, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+
+  const roleCookie = serialize(ROLE_COOKIE_NAME, '', {
+    httpOnly: false,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+
+  res.setHeader('Set-Cookie', [sessionCookie, roleCookie]);
+}
+
+export { COOKIE_NAME, ROLE_COOKIE_NAME };

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -76,7 +76,7 @@ export function withAuth(handler: AuthenticatedHandler, allowedRoles?: ('admin' 
       
       if (!token) {
         // Intentar obtener de cookies
-        const cookieToken = req.cookies?.authToken;
+        const cookieToken = req.cookies?.session;
         if (cookieToken) {
           token = cookieToken;
         }

--- a/src/pages/api/auth/login/index.ts
+++ b/src/pages/api/auth/login/index.ts
@@ -2,6 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '@/lib/supabase/server';
 import { comparePassword, generateToken, hashPassword } from '@/lib/auth';
+import { setSessionCookie } from '@/lib/auth/cookie';
 
 // API de login
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -31,10 +32,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (isAdminPasswordValid) {
       const token = generateToken({ id: 0, email: adminEmail, role: 'admin' });
+      setSessionCookie(res, token, 'admin');
       return res.status(200).json({
         role: 'admin',
         superAdmin: true,
-        token,
         message: 'Login exitoso',
       });
     }
@@ -95,6 +96,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       role,
     });
 
+    setSessionCookie(res, token, role);
+
     await supabase
       .from('Staff')
       .update({ Active: true })
@@ -106,7 +109,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ID_Grupo: null,
       ID_Base: staff.ID_Base,
       ID_Calificador: staff.ID_Staff,
-      token,
       message: 'Login exitoso',
     });
   } catch (error) {

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,19 +1,29 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '@/lib/supabase/server';
 import { verifyToken } from '@/lib/auth';
+import { clearSessionCookie, COOKIE_NAME } from '@/lib/auth/cookie';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const authHeader = req.headers.authorization;
-  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  // Read token from cookie first, fall back to Authorization header
+  let token: string | null = req.cookies?.[COOKIE_NAME] ?? null;
+
+  if (!token) {
+    const authHeader = req.headers.authorization;
+    token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  }
+
   const decoded = token ? verifyToken(token) : null;
 
   if (!decoded) {
     return res.status(401).json({ error: 'No autorizado' });
   }
+
+  // Clear session cookies
+  clearSessionCookie(res);
 
   if (decoded.id === 0) {
     return res.status(200).json({ message: 'Logout ok' });

--- a/src/pages/api/auth/me.ts
+++ b/src/pages/api/auth/me.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { verifyToken } from '@/lib/auth';
+import { COOKIE_NAME } from '@/lib/auth/cookie';
+
+/**
+ * GET /api/auth/me
+ * Lightweight session validation endpoint.
+ * Reads the session cookie, verifies the JWT, and returns user info.
+ * No DB call — pure JWT decode.
+ */
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Método no permitido' });
+  }
+
+  // Read token from cookie first, fall back to Authorization header
+  let token: string | null = req.cookies?.[COOKIE_NAME] ?? null;
+
+  if (!token) {
+    const authHeader = req.headers.authorization;
+    token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  }
+
+  if (!token) {
+    return res.status(401).json({ error: 'No autenticado' });
+  }
+
+  const decoded = verifyToken(token);
+
+  if (!decoded) {
+    return res.status(401).json({ error: 'Token inválido o expirado' });
+  }
+
+  return res.status(200).json({
+    id: decoded.id,
+    email: decoded.email,
+    role: decoded.role,
+  });
+}


### PR DESCRIPTION
## Related work item

Closes #89

## Summary

Migrated the authentication system from `localStorage`-based JWTs to `HttpOnly` cookies. Added a `/api/auth/me` endpoint to provide secure session validation for frontend hooks without exposing the token. Also fixed image compression memory leaks and invalid state bugs in `useRegisterForm`.

## Context

The previous authentication method was susceptible to XSS due to token storage in `localStorage`. This migration ensures the `session` token is invisible to frontend JS while still allowing React hooks to selectively read the `authRole` cookie for rendering purposes. 
In addition, memory leaks identified via Copilot have been patched by correctly using `URL.revokeObjectURL()`.

## Testing

- [x] `npm run lint` passes without new errors
- [x] `npm run build` completes successfully
- [x] `npx vitest run` passes (if applicable) (80/80 tests passing!)

## Impact

No breaking changes for end users, but the `db:seed` script was included to ease QA data generation. All feature containers no longer need to manually inject `Authorization: Bearer <token>` into fetch headers, as `authFetch` abstracts it.
