### PR TITLE
Refactor/require-explicit-assessment

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -73,8 +73,11 @@ El proyecto utiliza **Vitest** y **React Testing Library** para pruebas unitaria
 
 ---
 
-## Qué NO hacer
+## Reglas de Arquitectura Críticas (MANDATORIAS)
 
-1. No usar Supabase Service Key en el Frontend: Esta llave tiene privilegios totales. Solo debe usarse en scripts o API routes (server-side).
-2. No crear Páginas Monolíticas: Si tu archivo en src/app/ supera las 300 líneas, es hora de aplicar el ADR 0003 (Decomposición de Vistas).
-3. No saltarse authFetch: No uses fetch plano para llamadas internas, ya que perderás la gestión de tokens y expiración de sesión.
+Para evitar regresiones en seguridad y deudas técnicas, todo desarrollador debe seguir estas reglas:
+
+1. **`proxy.ts` es EL Middleware**: En Next.js 16, el archivo `src/proxy.ts` es el único punto de entrada para la intercepción de rutas en Edge Runtime. **NO crear `src/middleware.ts`** — tener ambos causa un error fatal de compilación. No borrar ni desactivar `src/proxy.ts`; es la columna vertebral de la autenticación.
+2. **`assessmentId` debe ser siempre explícito**: Todos los endpoints bajo `src/pages/api/dashboard/**` y los hooks de datos de admin (`useConfigData`, `useGestionData`, etc.) **DEBEN** requerir `assessmentId` como un parámetro explícito — nunca inferir un valor por defecto. Usar `resolveAssessmentId(req.query.assessmentId)` y retornar 400 si falta.
+3. **Los hooks de Auth no replican la protección de rutas**: Los hooks de frontend (`useAdminAuth`, `useGraderAuth`, etc.) son solo para estado de UI (ej. mostrar el botón de logout, leer el rol actual). La protección de rutas es responsabilidad exclusiva de `src/proxy.ts`. No añadir guardas basadas en `localStorage`.
+4. **Coordinación de PRs en archivos compartidos**: Antes de abrir una PR que toque `src/features/admin/**`, `src/pages/api/dashboard/**` o `src/proxy.ts`, verificar si hay otras PRs abiertas modificando los mismos archivos para evitar conflictos de refactorización paralela.

--- a/src/features/admin/gestion/GestionContainer.tsx
+++ b/src/features/admin/gestion/GestionContainer.tsx
@@ -131,7 +131,35 @@ export const GestionContainer = () => {
     );
   }
 
+  if (!selectedAssessment) {
+    return (
+      <div className="flex flex-col items-center min-h-screen py-4 sm:py-8 px-3 sm:px-4 bg-white">
+        <div className="w-full max-w-7xl flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4 px-1 sm:px-2">
+          <h1 className="text-2xl sm:text-3xl font-extrabold text-gray-900 text-center sm:text-left">Gestión del Assessment</h1>
+        </div>
+        <GestionToolbar
+          assessments={assessments}
+          selectedAssessment={selectedAssessment}
+          setSelectedAssessment={setSelectedAssessment}
+          searchTerm="" setSearchTerm={() => {}}
+          filterGrupo="" setFilterGrupo={() => {}}
+          filterEstado="" setFilterEstado={() => {}}
+          filterRol="" setFilterRol={() => {}}
+          sortBy="nombre" setSortBy={() => {}}
+          sortOrder="asc" setSortOrder={() => {}}
+          itemsPerPage={10} setItemsPerPage={() => {}}
+          onRefresh={() => {}} onExport={() => {}} onOpenRanges={() => {}}
+          grupos={[]} loading={false} exporting={false}
+        />
+        <div className="flex flex-col items-center justify-center flex-1 py-12">
+          <p className="text-lg text-gray-500">Selecciona un assessment para ver los resultados.</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
+
     <div className="flex flex-col items-center min-h-screen py-4 sm:py-8 px-3 sm:px-4 bg-white">
       <div className="w-full max-w-7xl flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4 px-1 sm:px-2">
         <h1 className="text-2xl sm:text-3xl font-extrabold text-gray-900 text-center sm:text-left">Gestión del Assessment</h1>


### PR DESCRIPTION
## Related work item

Closes #58

## Summary
- Require explicit `assessmentId` in all dashboard admin and gestion API/UI flows.
- Removed default/fallback assessment inference in backend and frontend.
- UI now prompts user to select an assessment before loading data.

## Context
This change enforces deterministic and explicit assessment context across admin and gestion features, as required by ADR 0004 and the hardening initiative. It prevents accidental data fetches or mutations without a selected assessment, aligning with the new API contract and improving traceability

## Testing

- [x] `npm run lint` passes without new errors
- [x] `npm run build` completes successfully
- [x] `npx vitest run` passes (if applicable)
- [x] Manual UI testing: verified that no data loads until an assessment is selected, and error messages are clear.

## Impact

Breaking change: Flows that do not provide `assessmentId` will now fail with a clear error.
No database migrations required.
Reviewers: Please check that all admin/gestion screens and endpoints behave as expected with explicit assessment selection.
