### PR TITLE
feat: server-side token invalidation on logout (#108)

### DIFF
--- a/src/__tests__/api/assessment/create.test.ts
+++ b/src/__tests__/api/assessment/create.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken } from '@/__tests__/helpers/mockApiContext';
+import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken, setupRevokedTokenMock } from '@/__tests__/helpers/mockApiContext';
 
 // ── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -38,7 +38,12 @@ function setupSupabase({
       insert: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       single: vi.fn(),
+      maybeSingle: vi.fn(),
     };
+    if (table === 'RevokedTokens') {
+      chain.maybeSingle.mockResolvedValue({ data: null, error: null });
+      return chain;
+    }
     if (table === 'GrupoEstudiantil') {
       chain.single.mockResolvedValue(grupoResult);
     } else {
@@ -53,6 +58,7 @@ function setupSupabase({
 describe('POST /api/assessment/create', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setupRevokedTokenMock(supabase);
   });
 
   it('returns 405 for non-POST requests', async () => {

--- a/src/__tests__/api/assessment/delete.test.ts
+++ b/src/__tests__/api/assessment/delete.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken } from '@/__tests__/helpers/mockApiContext';
+import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken, setupRevokedTokenMock } from '@/__tests__/helpers/mockApiContext';
 
 // ── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -28,12 +28,24 @@ const TABLES_IN_ORDER = ['CalificacionesPorPersona', 'Participante', 'Staff', 'B
 
 /** Sets up all 6 DELETE calls to succeed. Pass `failAt` to make one fail. */
 function setupCascadeSupabase(failAt?: string, failMsg = 'DB error') {
-  mockFrom.mockImplementation((table: string) => ({
-    delete: vi.fn().mockReturnThis(),
-    eq: vi.fn().mockResolvedValue(
+  mockFrom.mockImplementation((table: string) => {
+    const chain = {
+      delete: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn(),
+    };
+
+    if (table === 'RevokedTokens') {
+      chain.maybeSingle.mockResolvedValue({ data: null, error: null });
+      return chain;
+    }
+
+    chain.eq.mockResolvedValue(
       table === failAt ? { error: { message: failMsg } } : { error: null }
-    ),
-  }));
+    );
+    return chain;
+  });
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -42,6 +54,7 @@ describe('DELETE /api/assessment/delete', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv('ADMIN_DELETE_PASSWORD', 'correct-password');
+    setupRevokedTokenMock(supabase);
   });
 
   it('returns 405 for non-DELETE requests', async () => {

--- a/src/__tests__/api/assessment/list.test.ts
+++ b/src/__tests__/api/assessment/list.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken } from '@/__tests__/helpers/mockApiContext';
+import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken, setupRevokedTokenMock } from '@/__tests__/helpers/mockApiContext';
 
 vi.mock('@/lib/supabase/server', () => ({
   supabase: { from: vi.fn() },
@@ -37,6 +37,7 @@ function buildThenable(data: unknown, error: unknown = null) {
     select: vi.fn(),
     order: vi.fn(),
     eq: vi.fn(),
+    maybeSingle: vi.fn(),
     then: resolved.then.bind(resolved),
     catch: resolved.catch.bind(resolved),
     finally: resolved.finally.bind(resolved),
@@ -45,12 +46,14 @@ function buildThenable(data: unknown, error: unknown = null) {
   (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
   (chain.order as ReturnType<typeof vi.fn>).mockReturnValue(chain);
   (chain.eq as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  (chain.maybeSingle as ReturnType<typeof vi.fn>).mockReturnValue(chain);
   return chain;
 }
 
 describe('GET /api/assessment/list', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setupRevokedTokenMock(supabase);
   });
 
   it('returns 405 for non-GET requests', async () => {
@@ -70,8 +73,16 @@ describe('GET /api/assessment/list', () => {
 
   it('super-admin gets all assessments', async () => {
     mockVerifyToken.mockReturnValue(mockSuperAdminToken());
-    // Super-admin never calls getAuthorizedAssessmentId, so only 1 from() call
-    mockFrom.mockReturnValue(buildThenable(SAMPLE_ASSESSMENTS));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+        };
+      }
+      return buildThenable(SAMPLE_ASSESSMENTS);
+    });
     const req = createMockReq({ method: 'GET', cookies: { session: 'tok' } });
     const res = createMockRes();
     await handler(req, res);
@@ -85,7 +96,16 @@ describe('GET /api/assessment/list', () => {
     // For regular admin, getAuthorizedAssessmentId does NOT call supabase — it reads from JWT.
     // So only one from() call for the actual query.
     mockVerifyToken.mockReturnValue(mockAdminToken(1));
-    mockFrom.mockReturnValue(buildThenable([SAMPLE_ASSESSMENTS[0]]));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+        };
+      }
+      return buildThenable([SAMPLE_ASSESSMENTS[0]]);
+    });
     const req = createMockReq({ method: 'GET', cookies: { session: 'tok' } });
     const res = createMockRes();
     await handler(req, res);
@@ -97,7 +117,16 @@ describe('GET /api/assessment/list', () => {
 
   it('returns empty array when no assessments exist', async () => {
     mockVerifyToken.mockReturnValue(mockSuperAdminToken());
-    mockFrom.mockReturnValue(buildThenable([]));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+        };
+      }
+      return buildThenable([]);
+    });
     const req = createMockReq({ method: 'GET', cookies: { session: 'tok' } });
     const res = createMockRes();
     await handler(req, res);
@@ -107,7 +136,16 @@ describe('GET /api/assessment/list', () => {
 
   it('returns 500 when Supabase query fails', async () => {
     mockVerifyToken.mockReturnValue(mockSuperAdminToken());
-    mockFrom.mockReturnValue(buildThenable(null, { message: 'db error' }));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+        };
+      }
+      return buildThenable(null, { message: 'db error' });
+    });
     const req = createMockReq({ method: 'GET', cookies: { session: 'tok' } });
     const res = createMockRes();
     await handler(req, res);

--- a/src/__tests__/api/assessment/toggle-active.test.ts
+++ b/src/__tests__/api/assessment/toggle-active.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken } from '@/__tests__/helpers/mockApiContext';
+import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken, setupRevokedTokenMock } from '@/__tests__/helpers/mockApiContext';
 
 vi.mock('@/lib/supabase/server', () => ({
   supabase: { from: vi.fn() },
@@ -25,6 +25,7 @@ const mockFrom = supabase.from as ReturnType<typeof vi.fn>;
 describe('POST /api/assessment/toggle-active', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setupRevokedTokenMock(supabase);
   });
 
   it('returns 405 for non-POST requests', async () => {
@@ -71,7 +72,14 @@ describe('POST /api/assessment/toggle-active', () => {
   it('activates assessment and calls deactivation of siblings', async () => {
     mockVerifyToken.mockReturnValue(mockAdminToken(5));
     let callIndex = 0;
-    mockFrom.mockImplementation(() => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+        };
+      }
       callIndex++;
       if (callIndex === 1) {
         // First call: update + select + single → returns the updated assessment
@@ -101,21 +109,30 @@ describe('POST /api/assessment/toggle-active', () => {
     const res = createMockRes();
     await handler(req, res);
     expect(res.status).toHaveBeenCalledWith(200);
-    // Two from() calls: one for update, one for sibling deactivation
-    expect(mockFrom).toHaveBeenCalledTimes(2);
+    // Three from() calls: one for RevokedTokens, one for update, one for sibling deactivation
+    expect(mockFrom).toHaveBeenCalledTimes(3);
   });
 
   it('deactivating does NOT trigger sibling deactivation', async () => {
     mockVerifyToken.mockReturnValue(mockAdminToken(5));
-    mockFrom.mockImplementation(() => ({
-      update: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({
-        data: { ID_Assessment: 5, Activo_Assessment: false, ID_GrupoEstudiantil: 2 },
-        error: null,
-      }),
-    }));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+        };
+      }
+      return {
+        update: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { ID_Assessment: 5, Activo_Assessment: false, ID_GrupoEstudiantil: 2 },
+          error: null,
+        }),
+      };
+    });
 
     const req = createMockReq({
       method: 'POST',
@@ -125,18 +142,27 @@ describe('POST /api/assessment/toggle-active', () => {
     const res = createMockRes();
     await handler(req, res);
     expect(res.status).toHaveBeenCalledWith(200);
-    // Only ONE from() call: no sibling deactivation when setting activo=false
-    expect(mockFrom).toHaveBeenCalledTimes(1);
+    // Two from() calls: one for RevokedTokens, one for update (no sibling deactivation)
+    expect(mockFrom).toHaveBeenCalledTimes(2);
   });
 
   it('returns 500 when Supabase update fails', async () => {
     mockVerifyToken.mockReturnValue(mockAdminToken(5));
-    mockFrom.mockImplementation(() => ({
-      update: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({ data: null, error: { message: 'fail' } }),
-    }));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+        };
+      }
+      return {
+        update: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'fail' } }),
+      };
+    });
     const req = createMockReq({
       method: 'POST',
       cookies: { session: 'tok' },
@@ -149,15 +175,24 @@ describe('POST /api/assessment/toggle-active', () => {
 
   it('super-admin can toggle any assessment without assessmentId in their token', async () => {
     mockVerifyToken.mockReturnValue(mockSuperAdminToken()); // No assessmentId in token
-    mockFrom.mockImplementation(() => ({
-      update: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({
-        data: { ID_Assessment: 7, Activo_Assessment: true, ID_GrupoEstudiantil: 3 },
-        error: null,
-      }),
-    }));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+        };
+      }
+      return {
+        update: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { ID_Assessment: 7, Activo_Assessment: true, ID_GrupoEstudiantil: 3 },
+          error: null,
+        }),
+      };
+    });
     const req = createMockReq({
       method: 'POST',
       cookies: { session: 'tok' },

--- a/src/__tests__/api/assessment/update.test.ts
+++ b/src/__tests__/api/assessment/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken } from '@/__tests__/helpers/mockApiContext';
+import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken, setupRevokedTokenMock } from '@/__tests__/helpers/mockApiContext';
 
 vi.mock('@/lib/supabase/server', () => ({
   supabase: { from: vi.fn() },
@@ -27,17 +27,25 @@ function setupSupabase({
   fetchGroupResult = { data: { ID_GrupoEstudiantil: 5 }, error: null },
   deactivateResult = { error: null },
 } = {}) {
-  let callCount = 0;
-  mockFrom.mockImplementation(() => {
-    callCount++;
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'RevokedTokens') {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+      };
+    }
     return {
       update: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       neq: vi.fn().mockReturnThis(),
-      // 1st call = update, 2nd = fetchGroup, 3rd = deactivate siblings
-      single: vi.fn().mockResolvedValue(callCount === 1 ? updateResult : fetchGroupResult),
-      // deactivate siblings resolves without .single()
+      single: vi.fn().mockImplementation(() => {
+        if (table === 'Assessment') return Promise.resolve(updateResult);
+        if (table === 'Participante') return Promise.resolve(fetchGroupResult);
+        return Promise.resolve({ data: null, error: null });
+      }),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
       mockResolvedValue: vi.fn().mockResolvedValue(deactivateResult),
     };
   });
@@ -46,6 +54,7 @@ function setupSupabase({
 describe('PUT /api/assessment/update', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setupRevokedTokenMock(supabase);
   });
 
   it('returns 405 for non-PUT requests', async () => {
@@ -65,6 +74,7 @@ describe('PUT /api/assessment/update', () => {
 
   it('returns 400 when no fields are provided', async () => {
     mockVerifyToken.mockReturnValue(mockSuperAdminToken({ assessmentId: 10 } as any));
+    setupSupabase();
     const req = createMockReq({
       method: 'PUT',
       cookies: { session: 'tok' },
@@ -78,6 +88,7 @@ describe('PUT /api/assessment/update', () => {
 
   it('returns 400 when grupoEstudiantilId is NaN', async () => {
     mockVerifyToken.mockReturnValue(mockSuperAdminToken({ assessmentId: 10 } as any));
+    setupSupabase();
     const req = createMockReq({
       method: 'PUT',
       cookies: { session: 'tok' },
@@ -91,6 +102,7 @@ describe('PUT /api/assessment/update', () => {
 
   it('returns 403 when regular admin tries to update a different assessment', async () => {
     mockVerifyToken.mockReturnValue(mockAdminToken(10));
+    setupSupabase();
     const req = createMockReq({
       method: 'PUT',
       cookies: { session: 'tok' },
@@ -104,12 +116,7 @@ describe('PUT /api/assessment/update', () => {
 
   it('updates successfully with only nombre', async () => {
     mockVerifyToken.mockReturnValue(mockAdminToken(10));
-    mockFrom.mockImplementation(() => ({
-      update: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({ data: { ID_Assessment: 10 }, error: null }),
-    }));
+    setupSupabase({ updateResult: { data: { ID_Assessment: 10 }, error: null } });
     const req = createMockReq({
       method: 'PUT',
       cookies: { session: 'tok' },
@@ -123,12 +130,7 @@ describe('PUT /api/assessment/update', () => {
 
   it('returns 500 when Supabase update fails', async () => {
     mockVerifyToken.mockReturnValue(mockAdminToken(10));
-    mockFrom.mockImplementation(() => ({
-      update: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({ data: null, error: { message: 'db fail' } }),
-    }));
+    setupSupabase({ updateResult: { data: null, error: { message: 'db fail' } } });
     const req = createMockReq({
       method: 'PUT',
       cookies: { session: 'tok' },
@@ -140,13 +142,8 @@ describe('PUT /api/assessment/update', () => {
   });
 
   it('super-admin can update any assessment without assessmentId in their token', async () => {
-    mockVerifyToken.mockReturnValue(mockSuperAdminToken()); // No assessmentId in token
-    mockFrom.mockImplementation(() => ({
-      update: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({ data: { ID_Assessment: 7 }, error: null }),
-    }));
+    mockVerifyToken.mockReturnValue(mockSuperAdminToken());
+    setupSupabase({ updateResult: { data: { ID_Assessment: 7 }, error: null } });
     const req = createMockReq({
       method: 'PUT',
       cookies: { session: 'tok' },

--- a/src/__tests__/api/super-admin/staff-create.test.ts
+++ b/src/__tests__/api/super-admin/staff-create.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken } from '@/__tests__/helpers/mockApiContext';
+import { createMockReq, createMockRes, mockAdminToken, mockSuperAdminToken, setupRevokedTokenMock } from '@/__tests__/helpers/mockApiContext';
 
 vi.mock('@/lib/supabase/server', () => ({
   supabase: { from: vi.fn() },
@@ -25,10 +25,19 @@ const mockVerifyToken = verifyToken as ReturnType<typeof vi.fn>;
 const mockFrom = supabase.from as ReturnType<typeof vi.fn>;
 
 function setupInsert(result: { data: unknown; error: unknown }) {
-  mockFrom.mockReturnValue({
-    insert: vi.fn().mockReturnThis(),
-    select: vi.fn().mockReturnThis(),
-    single: vi.fn().mockResolvedValue(result),
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'RevokedTokens') {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+      };
+    }
+    return {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(result),
+    };
   });
 }
 
@@ -42,6 +51,7 @@ const VALID_BODY = {
 describe('POST /api/super-admin/staff-create', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setupRevokedTokenMock(supabase);
   });
 
   it('returns 405 for non-POST requests', async () => {

--- a/src/__tests__/api/switch-assessment.test.ts
+++ b/src/__tests__/api/switch-assessment.test.ts
@@ -4,11 +4,20 @@ import http from 'http';
 
 vi.mock('@/lib/supabase/server', () => ({
   supabase: {
-    from: vi.fn(() => ({
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({ data: { ID_Assessment: 5 }, error: null }),
-    })),
+    from: vi.fn((table: string) => {
+      if (table === 'RevokedTokens') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { ID_Assessment: 5 }, error: null }),
+      };
+    }),
   },
 }));
 

--- a/src/__tests__/helpers/mockApiContext.ts
+++ b/src/__tests__/helpers/mockApiContext.ts
@@ -51,6 +51,26 @@ export function buildSupabaseChain(result: { data: unknown; error: unknown }) {
     eq: vi.fn().mockReturnThis(),
     neq: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue(result),
+    maybeSingle: vi.fn().mockResolvedValue(result),
   };
   return chain;
+}
+
+/** 
+ * Helper to setup a default non-revoked token mock for requireRoles.
+ * Call this in beforeEach for API tests that use requireRoles.
+ */
+export function setupRevokedTokenMock(supabase: any) {
+  // Por defecto, el token NO está revocado
+  supabase.from.mockImplementation((table: string) => {
+    if (table === 'RevokedTokens') {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+      };
+    }
+    // Para otras tablas, retornar el mock por defecto o dejar que el test lo defina
+    return buildSupabaseChain({ data: null, error: null });
+  });
 }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -220,3 +220,15 @@ create index if not exists "IX_Calif_Participante"
 create unique index if not exists "UX_Calif_NoDuplicado"
   on public."CalificacionesPorPersona"
   ("ID_Assessment", "ID_Base", "ID_Staff", "ID_Participante");
+
+-- -------------------------
+-- RevokedTokens (Blacklist para Logout Seguro)
+-- -------------------------
+create table if not exists public."RevokedTokens" (
+  "Token" text primary key,
+  "ExpiresAt" timestamptz not null,
+  "CreatedAt" timestamptz not null default now()
+);
+
+create index if not exists "IX_RevokedTokens_ExpiresAt"
+  on public."RevokedTokens" ("ExpiresAt");

--- a/src/lib/auth/apiAuth.ts
+++ b/src/lib/auth/apiAuth.ts
@@ -1,14 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { verifyToken, type TokenPayload } from '@/lib/auth';
 import { COOKIE_NAME } from '@/lib/auth/cookie';
+import { supabase } from '@/lib/supabase/server';
 
 type Role = TokenPayload['role'];
 
-export function requireRoles(
+export async function requireRoles(
   req: NextApiRequest,
   res: NextApiResponse,
   allowed: Role[]
-): TokenPayload | null {
+): Promise<TokenPayload | null> {
   // Read token from cookie first, fall back to Authorization header
   let token: string | null = req.cookies?.[COOKIE_NAME] ?? null;
 
@@ -19,8 +20,21 @@ export function requireRoles(
 
   const decoded = token ? verifyToken(token) : null;
 
-  if (!decoded || !allowed.includes(decoded.role)) {
+  if (!decoded || !token || !allowed.includes(decoded.role)) {
     res.status(401).json({ error: 'No autorizado' });
+    return null;
+  }
+
+  // 🛡️ Verificar Blacklist (RevokedTokens)
+  const { data: revoked, error: revokedError } = await supabase
+    .from('RevokedTokens')
+    .select('Token')
+    .eq('Token', token)
+    .maybeSingle();
+
+  if (revokedError || revoked) {
+    console.warn('[requireRoles] Acceso denegado: Token revocado');
+    res.status(401).json({ error: 'Sesión terminada' });
     return null;
   }
 

--- a/src/lib/auth/blacklist.test.ts
+++ b/src/lib/auth/blacklist.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requireRoles } from '@/lib/auth/apiAuth';
+import { supabase } from '@/lib/supabase/server';
+import { verifyToken } from '@/lib/auth';
+
+vi.mock('@/lib/supabase/server', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn()
+        }))
+      }))
+    }))
+  }
+}));
+
+vi.mock('@/lib/auth', () => ({
+  verifyToken: vi.fn(),
+}));
+
+describe('Blacklist Security (RevokedTokens)', () => {
+  const mockReq = (cookie: string) => ({
+    cookies: { session: cookie },
+    headers: {}
+  } as any);
+
+  const mockRes = () => {
+    const res: any = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should deny access if token is in RevokedTokens table', async () => {
+    const token = 'revoked-token-123';
+    const req = mockReq(token);
+    const res = mockRes();
+
+    // Simular que el token es válido por firma
+    (verifyToken as any).mockReturnValue({ id: 1, role: 'admin' });
+
+    // Simular que el token ESTÁ en la blacklist
+    const maybeSingleMock = vi.fn().mockResolvedValue({ 
+      data: { Token: token }, 
+      error: null 
+    });
+    (supabase.from as any).mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: maybeSingleMock
+        }))
+      }))
+    });
+
+    const result = await requireRoles(req, res, ['admin']);
+
+    expect(result).toBeNull();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Sesión terminada' });
+  });
+
+  it('should allow access if token is NOT in RevokedTokens table', async () => {
+    const token = 'valid-token-456';
+    const req = mockReq(token);
+    const res = mockRes();
+
+    (verifyToken as any).mockReturnValue({ id: 1, role: 'admin' });
+
+    // Simular que el token NO está en la blacklist
+    const maybeSingleMock = vi.fn().mockResolvedValue({ 
+      data: null, 
+      error: null 
+    });
+    (supabase.from as any).mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: maybeSingleMock
+        }))
+      }))
+    });
+
+    const result = await requireRoles(req, res, ['admin']);
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,6 +1,8 @@
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabase/server';
+import { COOKIE_NAME } from './cookie';
 
 // Constantes de configuración
 const JWT_SECRET = process.env.JWT_SECRET ?? '';
@@ -73,14 +75,11 @@ export function withAuth(handler: AuthenticatedHandler, allowedRoles?: ('admin' 
   return async (req: NextApiRequest, res: NextApiResponse) => {
     try {
       // Obtener token del header Authorization o cookies
-      let token = req.headers.authorization?.replace('Bearer ', '');
+      let token: string | null = req.cookies?.[COOKIE_NAME] ?? null;
 
       if (!token) {
-        // Intentar obtener de cookies
-        const cookieToken = req.cookies?.session;
-        if (cookieToken) {
-          token = cookieToken;
-        }
+        const authHeader = req.headers.authorization;
+        token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
       }
 
       if (!token) {
@@ -91,6 +90,18 @@ export function withAuth(handler: AuthenticatedHandler, allowedRoles?: ('admin' 
 
       if (!decoded) {
         return res.status(401).json({ error: 'No autorizado: Token inválido o expirado' });
+      }
+
+      // 🛡️ Verificar Blacklist (RevokedTokens)
+      const { data: revoked, error: revokedError } = await supabase
+        .from('RevokedTokens')
+        .select('Token')
+        .eq('Token', token)
+        .maybeSingle();
+
+      if (revokedError || revoked) {
+        console.warn('[withAuth] Acceso denegado: Token revocado');
+        return res.status(401).json({ error: 'Sesión terminada' });
       }
 
       // Verificar roles permitidos si se especifican
@@ -106,6 +117,7 @@ export function withAuth(handler: AuthenticatedHandler, allowedRoles?: ('admin' 
     }
   };
 }
+
 
 /**
  * Middleware solo para administradores

--- a/src/pages/api/add-calificaciones/index.ts
+++ b/src/pages/api/add-calificaciones/index.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ message: "Método no permitido" });
   }
 
-  if (!requireRoles(req, res, ["admin", "calificador"])) return;
+  if (!await requireRoles(req, res, ["admin", "calificador"])) return;
 
   const { calificaciones: calificacionesArray, idGrupo: idGrupoBody } = typeof req.body?.calificaciones === 'undefined'
     ? { calificaciones: req.body, idGrupo: undefined }

--- a/src/pages/api/admin/hash-passwords.ts
+++ b/src/pages/api/admin/hash-passwords.ts
@@ -11,7 +11,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    if (!requireRoles(req, res, ['admin'])) return;
+    if (!await requireRoles(req, res, ['admin'])) return;
     const { data: staffList, error } = await supabase
       .from('Staff')
       .select('ID_Staff, Contrasena_Staff')

--- a/src/pages/api/admin/panel-data.ts
+++ b/src/pages/api/admin/panel-data.ts
@@ -7,7 +7,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!requireRoles(req, res, ['admin'])) return;
+  if (!await requireRoles(req, res, ['admin'])) return;
 
   try {
     const [groupsResult, assessmentsResult, adminsResult] = await Promise.all([

--- a/src/pages/api/assessment/auto-groups.ts
+++ b/src/pages/api/assessment/auto-groups.ts
@@ -32,7 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!requireRoles(req, res, ['admin'])) return;
+  if (!await requireRoles(req, res, ['admin'])) return;
 
   const { assessmentId, numGroups } = req.body ?? {};
   const assessmentIdNum = Number(assessmentId);

--- a/src/pages/api/assessment/bulk-create.ts
+++ b/src/pages/api/assessment/bulk-create.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!requireRoles(req, res, ['admin'])) return;
+  if (!await requireRoles(req, res, ['admin'])) return;
 
   const { grupoIds, activo } = req.body ?? {};
   const activeFlag = Boolean(activo);

--- a/src/pages/api/assessment/create.ts
+++ b/src/pages/api/assessment/create.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   if (user.id !== 0) {

--- a/src/pages/api/assessment/delete.ts
+++ b/src/pages/api/assessment/delete.ts
@@ -7,7 +7,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
   if (user.id !== 0) {
     return res.status(403).json({ error: 'Solo el super-admin puede eliminar assessments' });

--- a/src/pages/api/assessment/groups-active.ts
+++ b/src/pages/api/assessment/groups-active.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const assessmentId = user.id === 0 

--- a/src/pages/api/assessment/groups.ts
+++ b/src/pages/api/assessment/groups.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const assessmentId = user.id === 0 

--- a/src/pages/api/assessment/list-with-group.ts
+++ b/src/pages/api/assessment/list-with-group.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   let authorizedAssessmentId = null;

--- a/src/pages/api/assessment/list.ts
+++ b/src/pages/api/assessment/list.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const user = requireRoles(req, res, ['admin']);
+    const user = await requireRoles(req, res, ['admin']);
     if (!user) return;
     
     // Super-admins pueden ver todos los assessments sin restricción.

--- a/src/pages/api/assessment/toggle-active.ts
+++ b/src/pages/api/assessment/toggle-active.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const { assessmentId: payloadAssessmentId, activo } = req.body;

--- a/src/pages/api/assessment/update.ts
+++ b/src/pages/api/assessment/update.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const { assessmentId: payloadAssessmentId, nombre, descripcion, activo, grupoEstudiantilId } = req.body ?? {};

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -18,18 +18,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const decoded = token ? verifyToken(token) : null;
 
-  if (!decoded) {
+  if (!decoded || !token) {
     return res.status(401).json({ error: 'No autorizado' });
   }
 
-  // Clear session cookies
-  clearSessionCookie(res);
-
-  if (decoded.id === 0) {
-    return res.status(200).json({ message: 'Logout ok' });
-  }
+  // 1. Invalidar el token en el servidor (Blacklist)
+  // Usamos el exp del JWT para saber cuánto tiempo guardarlo.
+  // Si no tiene exp (raro), usamos 24h por defecto.
+  const expiresAt = decoded.exp 
+    ? new Date(decoded.exp * 1000).toISOString() 
+    : new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
 
   try {
+    await supabase
+      .from('RevokedTokens')
+      .insert({
+        Token: token,
+        ExpiresAt: expiresAt
+      });
+
+    // Clear session cookies
+    clearSessionCookie(res);
+
+    if (decoded.id === 0) {
+      return res.status(200).json({ message: 'Logout ok' });
+    }
+
     const { error } = await supabase
       .from('Staff')
       .update({ Active: false })

--- a/src/pages/api/auth/me.ts
+++ b/src/pages/api/auth/me.ts
@@ -1,14 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { verifyToken } from '@/lib/auth';
 import { COOKIE_NAME } from '@/lib/auth/cookie';
+import { supabase } from '@/lib/supabase/server';
 
 /**
  * GET /api/auth/me
  * Lightweight session validation endpoint.
  * Reads the session cookie, verifies the JWT, and returns user info.
- * No DB call — pure JWT decode.
+ * Checks RevokedTokens blacklist.
  */
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Método no permitido' });
   }
@@ -31,15 +32,22 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(401).json({ error: 'Token inválido o expirado' });
   }
 
-  if (decoded && typeof decoded === 'object') {
-    return res.status(200).json({
-      id: decoded.id,
-      email: decoded.email,
-      role: decoded.role,
-      isSuperAdmin: decoded.role === 'admin' && decoded.email === process.env.ADMIN_EMAIL,
-      assessmentId: decoded.assessmentId || null,
-    });
+  // 🛡️ Verificar Blacklist (RevokedTokens)
+  const { data: revoked, error: revokedError } = await supabase
+    .from('RevokedTokens')
+    .select('Token')
+    .eq('Token', token)
+    .maybeSingle();
+
+  if (revokedError || revoked) {
+    return res.status(401).json({ error: 'Sesión terminada' });
   }
 
-  return res.status(401).json({ error: 'Token inválido' });
+  return res.status(200).json({
+    id: decoded.id,
+    email: decoded.email,
+    role: decoded.role,
+    isSuperAdmin: decoded.role === 'admin' && decoded.email === process.env.ADMIN_EMAIL,
+    assessmentId: decoded.assessmentId || null,
+  });
 }

--- a/src/pages/api/base/create.ts
+++ b/src/pages/api/base/create.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const assessmentId = getAuthorizedAssessmentId(user, res);

--- a/src/pages/api/base/delete.ts
+++ b/src/pages/api/base/delete.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const assessmentId = getAuthorizedAssessmentId(user, res);

--- a/src/pages/api/base/list.ts
+++ b/src/pages/api/base/list.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const assessmentId = getAuthorizedAssessmentId(user, res);

--- a/src/pages/api/base/update.ts
+++ b/src/pages/api/base/update.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const assessmentId = getAuthorizedAssessmentId(user, res);

--- a/src/pages/api/check-already-graded.ts
+++ b/src/pages/api/check-already-graded.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!requireRoles(req, res, ['admin', 'calificador'])) return;
+  if (!await requireRoles(req, res, ['admin', 'calificador'])) return;
 
   const { idCalificador, idBase, idGrupo } = req.body;
 

--- a/src/pages/api/dashboard/config.ts
+++ b/src/pages/api/dashboard/config.ts
@@ -8,7 +8,7 @@ import { resolveParticipantPhotoUrls } from "@/lib/utils/imageUrl";
 // API para obtener datos del dashboard admin
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const user = requireRoles(req, res, ["admin"]);
+    const user = await requireRoles(req, res, ["admin"]);
     if (!user) return;
 
     const assessmentId = user.assessmentId;

--- a/src/pages/api/dashboard/gh.ts
+++ b/src/pages/api/dashboard/gh.ts
@@ -6,7 +6,7 @@ import { resolveParticipantPhotoUrls } from "@/lib/utils/imageUrl";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const user = requireRoles(req, res, ["admin"]);
+    const user = await requireRoles(req, res, ["admin"]);
     if (!user) return;
 
     // Si viene assessmentId en el query param, usarlo; si no, usar el del token

--- a/src/pages/api/db.ts
+++ b/src/pages/api/db.ts
@@ -5,7 +5,7 @@ import { requireRoles } from "@/lib/auth/apiAuth";
 // Endpoint de verificación de conexión para Supabase
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    if (!requireRoles(req, res, ["admin"])) return;
+    if (!await requireRoles(req, res, ["admin"])) return;
 
     const { data, error } = await supabase
       .from("Assessment")

--- a/src/pages/api/get-calificaciones-by-calificador.ts
+++ b/src/pages/api/get-calificaciones-by-calificador.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   // Verificar autenticación
-  if (!requireRoles(req, res, ['admin', 'calificador'])) return;
+  if (!await requireRoles(req, res, ['admin', 'calificador'])) return;
 
   try {
     const { idCalificador, idBase } = req.body;

--- a/src/pages/api/getCalificador.ts
+++ b/src/pages/api/getCalificador.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Solo se permite POST' });
   }
 
-  if (!requireRoles(req, res, ['admin', 'calificador'])) return;
+  if (!await requireRoles(req, res, ['admin', 'calificador'])) return;
 
   const { id_calificador } = req.body;
 

--- a/src/pages/api/grader/groups.ts
+++ b/src/pages/api/grader/groups.ts
@@ -12,7 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido. Usa POST.' });
   }
 
-  if (!requireRoles(req, res, ['admin', 'calificador'])) return;
+  if (!await requireRoles(req, res, ['admin', 'calificador'])) return;
 
   try {
     const { idCalificador, idBase } = req.body;

--- a/src/pages/api/grader/participants.ts
+++ b/src/pages/api/grader/participants.ts
@@ -12,7 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido. Usa POST.' });
   }
 
-  if (!requireRoles(req, res, ['admin', 'calificador'])) return;
+  if (!await requireRoles(req, res, ['admin', 'calificador'])) return;
 
   try {
     const { idCalificador, idGrupo } = req.body;

--- a/src/pages/api/grupo-estudiantil/list.ts
+++ b/src/pages/api/grupo-estudiantil/list.ts
@@ -7,7 +7,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!requireRoles(req, res, ['admin'])) return;
+  if (!await requireRoles(req, res, ['admin'])) return;
 
   try {
     const { data, error } = await supabase

--- a/src/pages/api/participante/assign-group.ts
+++ b/src/pages/api/participante/assign-group.ts
@@ -7,7 +7,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!requireRoles(req, res, ['admin'])) return;
+  if (!await requireRoles(req, res, ['admin'])) return;
 
   const { assessmentId, participanteId, grupoAssessmentId } = req.body;
 

--- a/src/pages/api/participante/list.ts
+++ b/src/pages/api/participante/list.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const assessmentId = user.assessmentId;

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -59,7 +59,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     // 🔐 Roles
-    const decoded = requireRoles(req, res, ['admin', 'registrador']);
+    const decoded = await requireRoles(req, res, ['admin', 'registrador']);
     if (!decoded) return;
     console.log(decoded);
 

--- a/src/pages/api/staff/admins.ts
+++ b/src/pages/api/staff/admins.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const authorizedAssessmentId = getAuthorizedAssessmentId(user, res);

--- a/src/pages/api/staff/bulk-create-admins.ts
+++ b/src/pages/api/staff/bulk-create-admins.ts
@@ -50,7 +50,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!requireRoles(req, res, ['admin'])) return;
+  if (!await requireRoles(req, res, ['admin'])) return;
 
   const { assessmentIds } = req.body ?? {};
   const targetIds =

--- a/src/pages/api/staff/create.ts
+++ b/src/pages/api/staff/create.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const { correo, password, rol, idBase } = req.body;

--- a/src/pages/api/staff/update.ts
+++ b/src/pages/api/staff/update.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   const { staffId, correo, password, assessmentId: payloadAssessmentId } = req.body ?? {};

--- a/src/pages/api/super-admin/staff-create.ts
+++ b/src/pages/api/super-admin/staff-create.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  const user = requireRoles(req, res, ['admin']);
+  const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
   // Restrict to super-admin

--- a/src/pages/api/update-person.ts
+++ b/src/pages/api/update-person.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!requireRoles(req, res, ['admin'])) return;
+  if (!await requireRoles(req, res, ['admin'])) return;
 
   const { id, nombre, correo, role } = req.body;
 


### PR DESCRIPTION
## Related work item
Closes #108

## Summary
Implemented server-side JWT invalidation (blacklist) during logout to ensure that tokens cannot be reused after a user has signed out.

## Context
Previously, logout only cleared the client-side cookie, but the JWT remained valid on the server until its expiration (8 hours). This implementation adds a `RevokedTokens` table to track invalidated tokens.

## Changes
- **Database**: Added `RevokedTokens` table to store revoked tokens and their expiration dates.
- **Logout API**: Updated `/api/auth/logout` to register the current token in the blacklist.
- **Auth Guard**: 
  - Updated `requireRoles` (apiAuth.ts) to be asynchronous and check the blacklist.
  - Updated `withAuth` middleware to reject revoked tokens.
  - Updated `/api/auth/me` to ensure immediate session termination.
- **Refactor**: Updated all 35 API endpoints to correctly `await` the new asynchronous `requireRoles` check.
- **Tests**: 
  - Added `blacklist.test.ts` to verify the invalidation logic.
  - Updated all existing API test suites to support the new database-dependent auth check.

## Testing
- [x] `npm run test` (162 tests passed successfully)
- [x] Verified token rejection after logout in local environment.

## Considerations
- A periodic cleanup of expired tokens from the `RevokedTokens` table is recommended (e.g., via a Supabase Edge Function or Cron Job).