### PR TITLE
feat: centralized AuthProvider

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -195,7 +195,7 @@ Autentica a un usuario admin, registrador o calificador.
   - 500: configuración de admin incompleta o error interno.
 
 ### POST /api/auth/logout
-Cierra la sesión del usuario autenticado.
+Cierra la sesión del usuario autenticado e invalida el token en el servidor.
 
 - Auth: cualquier usuario autenticado.
 - Respuesta (200 OK)
@@ -204,6 +204,23 @@ Cierra la sesión del usuario autenticado.
     "message": "Logout ok"
   }
   ```
+
+### GET /api/auth/me
+Valida la sesión actual a través de la cookie `session` y devuelve la información del perfil.
+
+- Auth: cualquier usuario con sesión activa.
+- Respuesta (200 OK)
+  ```json
+  {
+    "id": 14,
+    "email": "user@example.com",
+    "role": "admin" | "calificador" | "registrador",
+    "isSuperAdmin": boolean,
+    "assessmentId": 6 | null
+  }
+  ```
+- Errores
+  - 401: Token inválido, expirado o presente en la blacklist de `RevokedTokens`.
 
 ---
 
@@ -395,6 +412,23 @@ Crea un administrador para un assessment específico. Esta ruta bypassa la valid
   }
   ```
 
+### DELETE /api/assessment/delete-group
+Elimina un grupo específico. Desvincula a todos los participantes y staff asociados (set null) antes de borrar el registro del grupo.
+
+- Auth: admin
+- Payload
+  ```json
+  {
+    "id": 7
+  }
+  ```
+- Respuesta (200 OK)
+  ```json
+  {
+    "message": "Grupo eliminado con éxito"
+  }
+  ```
+
 ### GET /api/grupo-estudiantil/list
 Lista grupos estudiantiles disponibles.
 
@@ -526,6 +560,12 @@ Obtiene el detalle de una base por ID.
 
 ## Staff y Usuarios
 
+### GET /api/staff/list
+Lista todo el personal (admins, calificadores, registradores) asociado al assessment del usuario autenticado.
+
+- Auth: admin
+- Respuesta (200 OK): Arreglo de objetos con datos de staff normalizados (ID, Correo, rol, Active, etc).
+
 ### GET /api/staff/admins
 Lista administradores registrados.
 
@@ -538,23 +578,30 @@ Registra un miembro del staff.
 - Payload
   ```json
   {
-    "assessmentId": 6,
     "correo": "staff@example.com",
     "password": "string",
-    "rol": "admin",
-    "idBase": 2
+    "rol": "admin" | "calificador" | "registrador",
+    "idBase": 2 (opcional, solo para calificador)
   }
   ```
 
-### PUT /api/staff/update
-Actualiza datos de un miembro del staff.
+### PUT /api/staff/update-active
+Actualiza datos de un miembro del staff, incluyendo su estado activo y rol.
 
 - Auth: admin
 - Payload
   ```json
   {
-    "staffId": 14,
-    "correo": "nuevo@example.com"
+    "id": 14,
+    "correo": "nuevo@example.com",
+    "role": "admin",
+    "active": true
+  }
+  ```
+- Respuesta (200 OK)
+  ```json
+  {
+    "message": "Staff actualizado correctamente"
   }
   ```
 

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -2,16 +2,14 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useStoredId } from "@/hooks/useStoredId";
-import { useAdminAuth } from "@/hooks/useAdminAuth";
-import { useGraderAuth } from "@/hooks/useGraderAuth";
+import { useAuth } from "@/lib/auth/AuthContext";
 import { Box } from "@/components/UI/Box";
 import { InputBox } from "@/components/UI/InputBox";
 import { Button } from "@/components/UI/Button";
 
 export default function Login() {
   const { saveData } = useStoredId();
-  const { loginAsAdmin } = useAdminAuth();
-  const { loginAsGrader } = useGraderAuth();
+  const { login } = useAuth();
 
   const router = useRouter();
   const [email, setEmail] = useState("");
@@ -40,13 +38,32 @@ export default function Login() {
 
       if (data.role === "admin") {
         const isSuper = Boolean(data.superAdmin);
-        loginAsAdmin(isSuper);
+        login({
+          id: data.ID_Calificador || 0,
+          email: email,
+          role: "admin",
+          isSuperAdmin: isSuper,
+          assessmentId: data.assessmentId || null,
+        });
         router.push(isSuper ? "/super-admin" : "/admin");
       } else if (data.role === "registrador") {
+        login({
+          id: data.ID_Calificador,
+          email: email,
+          role: "registrador",
+          isSuperAdmin: false,
+          assessmentId: data.assessmentId || null,
+        });
         router.push("/register");
       } else if (data.role === "calificador") {
         saveData(data.ID_Grupo, data.ID_Calificador, data.ID_Base);
-        loginAsGrader();
+        login({
+          id: data.ID_Calificador,
+          email: email,
+          role: "calificador",
+          isSuperAdmin: false,
+          assessmentId: data.assessmentId || null,
+        });
         router.push(`/grader`);
       } else {
         router.push("/dashboard");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ToastProvider } from "@/components/UI/Toast";
 import ServiceWorkerRegistration from "@/components/ServiceWorkerRegistration";
+import { AuthProvider } from "@/lib/auth/AuthContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -46,9 +47,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
-        <ToastProvider />
-        <ServiceWorkerRegistration />
+        <AuthProvider>
+          {children}
+          <ToastProvider />
+          <ServiceWorkerRegistration />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/features/register/hooks/useRegisterAuth.test.ts
+++ b/src/features/register/hooks/useRegisterAuth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useRegisterAuth } from './useRegisterAuth';
+import { useAuth } from '@/lib/auth/AuthContext';
 
 const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -9,59 +10,66 @@ vi.mock('next/navigation', () => ({
   }),
 }));
 
+vi.mock('@/lib/auth/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
 describe('useRegisterAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should redirect to login when fetch fails (not authorized)', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+  it('should redirect to login when context indicates not authorized', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAdmin: false,
+      isRegistrar: false,
+      isLoading: false,
+      logout: vi.fn(),
+    } as any);
+
     const { result } = renderHook(() => useRegisterAuth());
 
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/auth/login');
-    });
+    expect(mockPush).toHaveBeenCalledWith('/auth/login');
+    expect(result.current.checkingAuth).toBe(false);
+  });
+
+  it('should stop checking auth for registrador role', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAdmin: false,
+      isRegistrar: true,
+      isLoading: false,
+      logout: vi.fn(),
+    } as any);
+
+    const { result } = renderHook(() => useRegisterAuth());
+
+    expect(result.current.checkingAuth).toBe(false);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('should stop checking auth for admin role', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAdmin: true,
+      isRegistrar: false,
+      isLoading: false,
+      logout: vi.fn(),
+    } as any);
+
+    const { result } = renderHook(() => useRegisterAuth());
+
+    expect(result.current.checkingAuth).toBe(false);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('should return loading state from context', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAdmin: false,
+      isRegistrar: false,
+      isLoading: true,
+      logout: vi.fn(),
+    } as any);
+
+    const { result } = renderHook(() => useRegisterAuth());
     expect(result.current.checkingAuth).toBe(true);
-  });
-
-  it('should redirect to login when role is invalid', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
-      ok: true, 
-      json: async () => ({ role: 'calificador' }) 
-    }));
-
-    renderHook(() => useRegisterAuth());
-
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/auth/login');
-    });
-  });
-
-  it('should stop checking auth for registrador role', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
-      ok: true, 
-      json: async () => ({ role: 'registrador' }) 
-    }));
-
-    const { result } = renderHook(() => useRegisterAuth());
-
-    await waitFor(() => {
-      expect(result.current.checkingAuth).toBe(false);
-    });
-    expect(mockPush).not.toHaveBeenCalled();
-  });
-
-  it('should stop checking auth for admin role', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
-      ok: true, 
-      json: async () => ({ role: 'admin' }) 
-    }));
-
-    const { result } = renderHook(() => useRegisterAuth());
-
-    await waitFor(() => {
-      expect(result.current.checkingAuth).toBe(false);
-    });
-    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/src/features/register/hooks/useRegisterAuth.ts
+++ b/src/features/register/hooks/useRegisterAuth.ts
@@ -1,39 +1,20 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth/AuthContext';
 
 /**
  * Auth guard for the register page.
- * Validates session via /api/auth/me cookie-based endpoint.
- * Redirects to /auth/login if not authorized.
+ * Refactored to use centralized AuthContext.
  */
 export const useRegisterAuth = () => {
   const router = useRouter();
-  const [checkingAuth, setCheckingAuth] = useState(true);
+  const { isRegistrar, isAdmin, isLoading, logout } = useAuth();
 
   useEffect(() => {
-    const checkAuth = async () => {
-      try {
-        const res = await fetch('/api/auth/me', { credentials: 'include' });
-        if (res.ok) {
-          const data = await res.json();
-          if (data.role === 'registrador' || data.role === 'admin') {
-            setCheckingAuth(false);
-            return;
-          }
-        }
-      } catch {
-        // Auth check failed
-      }
+    if (!isLoading && !isRegistrar && !isAdmin) {
       router.push('/auth/login');
-    };
+    }
+  }, [isLoading, isRegistrar, isAdmin, router]);
 
-    checkAuth();
-  }, [router]);
-
-  const logout = useCallback(async () => {
-    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
-    router.push('/auth/login');
-  }, [router]);
-
-  return { checkingAuth, logout };
+  return { checkingAuth: isLoading, logout };
 };

--- a/src/hooks/useAdminAuth.ts
+++ b/src/hooks/useAdminAuth.ts
@@ -1,64 +1,23 @@
-import { useState, useEffect, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth/AuthContext";
 
+/**
+ * useAdminAuth - Consumer hook for admin-related auth state.
+ * Refactored to use centralized AuthContext.
+ */
 export const useAdminAuth = () => {
-  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
-  const [isSuperAdmin, setIsSuperAdmin] = useState(false);
-  const [assessmentId, setAssessmentId] = useState<number | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const router = useRouter();
+  const { 
+    isAdmin, 
+    isSuperAdmin, 
+    assessmentId, 
+    isLoading, 
+    logout 
+  } = useAuth();
 
-  useEffect(() => {
-    let mounted = true;
-    const checkAuth = async () => {
-      try {
-        const res = await fetch("/api/auth/me", { credentials: "include" });
-        if (res.ok) {
-          const data = await res.json();
-          if (mounted && data.role === "admin") {
-            setIsAdmin(true);
-            setIsSuperAdmin(Boolean(data.isSuperAdmin));
-            setAssessmentId(data.assessmentId || null);
-          } else if (mounted) {
-            setIsAdmin(false);
-            setIsSuperAdmin(false);
-            setAssessmentId(null);
-          }
-        } else if (mounted) {
-          setIsAdmin(false);
-          setIsSuperAdmin(false);
-          setAssessmentId(null);
-        }
-      } catch {
-        if (mounted) {
-          setIsAdmin(false);
-          setIsSuperAdmin(false);
-          setAssessmentId(null);
-        }
-      }
-      if (mounted) setIsLoading(false);
-    };
-
-    checkAuth();
-    return () => { mounted = false; };
-  }, []);
-
-  const loginAsAdmin = useCallback((superAdmin = false, assId: number | null = null) => {
-    setIsAdmin(true);
-    setIsSuperAdmin(superAdmin);
-    setAssessmentId(assId);
-  }, []);
-
-  const logout = useCallback(async () => {
-    await fetch("/api/auth/logout", {
-      method: "POST",
-      credentials: "include",
-    });
-    setIsAdmin(false);
-    setIsSuperAdmin(false);
-    setAssessmentId(null);
-    router.push("/auth/login");
-  }, [router]);
-
-  return { isAdmin, isSuperAdmin, assessmentId, isLoading, loginAsAdmin, logout };
+  return { 
+    isAdmin, 
+    isSuperAdmin, 
+    assessmentId, 
+    isLoading, 
+    logout 
+  };
 };

--- a/src/hooks/useGraderAuth.ts
+++ b/src/hooks/useGraderAuth.ts
@@ -1,47 +1,24 @@
-import { useState, useEffect, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth/AuthContext";
 
+/**
+ * useGraderAuth - Consumer hook for grader-related auth state.
+ * Refactored to use centralized AuthContext.
+ */
 export const useGraderAuth = () => {
-  const [isGrader, setIsGrader] = useState<boolean | null>(null); // null = loading
-  const [isLoading, setIsLoading] = useState(true);
-  const router = useRouter();
+  const { 
+    isGrader, 
+    isLoading, 
+    logout: originalLogout 
+  } = useAuth();
 
-  useEffect(() => {
-    let mounted = true;
-    const checkAuth = async () => {
-      try {
-        const res = await fetch("/api/auth/me", { credentials: "include" });
-        if (res.ok) {
-          const data = await res.json();
-          if (mounted) {
-            setIsGrader(data.role === "calificador");
-          }
-        } else if (mounted) {
-          setIsGrader(false);
-        }
-      } catch {
-        if (mounted) setIsGrader(false);
-      }
-      if (mounted) setIsLoading(false);
-    };
-
-    checkAuth();
-    return () => { mounted = false; };
-  }, []);
-
-  const loginAsGrader = useCallback(() => {
-    setIsGrader(true);
-  }, []);
-
-  const logout = useCallback(async () => {
-    await fetch("/api/auth/logout", {
-      method: "POST",
-      credentials: "include",
-    });
+  const logout = async () => {
     localStorage.removeItem("storedData");
-    setIsGrader(false);
-    router.push("/auth/login");
-  }, [router]);
+    await originalLogout();
+  };
 
-  return { isGrader, isLoading, loginAsGrader, logout };
+  return { 
+    isGrader, 
+    isLoading, 
+    logout 
+  };
 };

--- a/src/hooks/useSuperAdminAuth.test.ts
+++ b/src/hooks/useSuperAdminAuth.test.ts
@@ -1,89 +1,67 @@
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useSuperAdminAuth } from './useSuperAdminAuth';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth/AuthContext';
 
-vi.mock('next/navigation', () => ({
-  useRouter: vi.fn(),
+vi.mock('@/lib/auth/AuthContext', () => ({
+  useAuth: vi.fn(),
 }));
 
 describe('useSuperAdminAuth', () => {
-  const mockPush = vi.fn();
+  const mockLogout = vi.fn();
   
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useRouter).mockReturnValue({ push: mockPush } as any);
   });
 
-  it('should initialize as not super admin if API returns non-admin role', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
-      ok: true, 
-      json: async () => ({ role: 'not-admin', isSuperAdmin: false }) 
-    }));
+  it('should return isSuperAdmin false when context returns isSuperAdmin false', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isSuperAdmin: false,
+      isLoading: false,
+      logout: mockLogout,
+    } as any);
 
     const { result } = renderHook(() => useSuperAdminAuth());
-    await waitFor(() => {
-      expect(result.current.isSuperAdmin).toBe(false);
-      expect(result.current.isLoading).toBe(false);
-    });
-  });
-
-  it('should identify super admin if API returns admin role and isSuperAdmin true', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
-      ok: true, 
-      json: async () => ({ role: 'admin', isSuperAdmin: true }) 
-    }));
-
-    const { result } = renderHook(() => useSuperAdminAuth());
-    
-    await waitFor(() => {
-      expect(result.current.isSuperAdmin).toBe(true);
-      expect(result.current.isLoading).toBe(false);
-    });
-  });
-
-  it('should identify as NOT super admin if API returns admin role but isSuperAdmin false', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
-      ok: true, 
-      json: async () => ({ role: 'admin', isSuperAdmin: false }) 
-    }));
-
-    const { result } = renderHook(() => useSuperAdminAuth());
-    
-    await waitFor(() => {
-      expect(result.current.isSuperAdmin).toBe(false);
-      expect(result.current.isLoading).toBe(false);
-    });
-  });
-
-  it('should identify as NOT super admin if API request fails', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
-      ok: false,
-      status: 401
-    }));
-
-    const { result } = renderHook(() => useSuperAdminAuth());
-    
-    await waitFor(() => {
-      expect(result.current.isSuperAdmin).toBe(false);
-      expect(result.current.isLoading).toBe(false);
-    });
-  });
-
-  it('logout should call api, clear state and redirect', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ 
-      ok: true, 
-      json: async () => ({ role: 'admin', isSuperAdmin: true }) 
-    }));
-
-    const { result } = renderHook(() => useSuperAdminAuth());
-    await waitFor(() => expect(result.current.isSuperAdmin).toBe(true));
-
-    await act(async () => {
-      result.current.logout();
-    });
-
     expect(result.current.isSuperAdmin).toBe(false);
-    expect(mockPush).toHaveBeenCalledWith('/auth/login');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return isSuperAdmin true when context returns isSuperAdmin true', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isSuperAdmin: true,
+      isLoading: false,
+      logout: mockLogout,
+    } as any);
+
+    const { result } = renderHook(() => useSuperAdminAuth());
+    expect(result.current.isSuperAdmin).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return loading state from context', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isSuperAdmin: false,
+      isLoading: true,
+      logout: mockLogout,
+    } as any);
+
+    const { result } = renderHook(() => useSuperAdminAuth());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('logout should call logout from context', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isSuperAdmin: true,
+      isLoading: false,
+      logout: mockLogout,
+    } as any);
+
+    const { result } = renderHook(() => useSuperAdminAuth());
+    
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(mockLogout).toHaveBeenCalled();
   });
 });

--- a/src/hooks/useSuperAdminAuth.ts
+++ b/src/hooks/useSuperAdminAuth.ts
@@ -1,44 +1,19 @@
-import { useState, useEffect, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth/AuthContext";
 
+/**
+ * useSuperAdminAuth - Consumer hook for super-admin-related auth state.
+ * Refactored to use centralized AuthContext.
+ */
 export const useSuperAdminAuth = () => {
-  const [isSuperAdmin, setIsSuperAdmin] = useState<boolean | null>(null); // null = loading
-  const [isLoading, setIsLoading] = useState(true);
-  const router = useRouter();
+  const { 
+    isSuperAdmin, 
+    isLoading, 
+    logout 
+  } = useAuth();
 
-  useEffect(() => {
-    let mounted = true;
-    const checkAuth = async () => {
-      try {
-        const res = await fetch("/api/auth/me", { credentials: "include" });
-        if (res.ok) {
-          const data = await res.json();
-          if (mounted && data.role === "admin") {
-            setIsSuperAdmin(Boolean(data.isSuperAdmin));
-          } else if (mounted) {
-            setIsSuperAdmin(false);
-          }
-        } else if (mounted) {
-          setIsSuperAdmin(false);
-        }
-      } catch {
-        if (mounted) setIsSuperAdmin(false);
-      }
-      if (mounted) setIsLoading(false);
-    };
-
-    checkAuth();
-    return () => { mounted = false; };
-  }, []);
-
-  const logout = useCallback(async () => {
-    await fetch("/api/auth/logout", {
-      method: "POST",
-      credentials: "include",
-    });
-    setIsSuperAdmin(false);
-    router.push("/auth/login");
-  }, [router]);
-
-  return { isSuperAdmin, isLoading, logout };
+  return { 
+    isSuperAdmin, 
+    isLoading, 
+    logout 
+  };
 };

--- a/src/lib/auth/AuthContext.tsx
+++ b/src/lib/auth/AuthContext.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface AuthUser {
+  id: number;
+  email: string;
+  role: 'admin' | 'calificador' | 'registrador';
+  isSuperAdmin: boolean;
+  assessmentId: number | null;
+}
+
+interface AuthContextType {
+  user: AuthUser | null;
+  isAdmin: boolean;
+  isSuperAdmin: boolean;
+  isGrader: boolean;
+  isRegistrar: boolean;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  assessmentId: number | null;
+  login: (userData: AuthUser) => void;
+  logout: () => Promise<void>;
+  refreshAuth: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const router = useRouter();
+
+  const refreshAuth = useCallback(async () => {
+    try {
+      const res = await fetch("/api/auth/me", { credentials: "include" });
+      if (res.ok) {
+        const data = await res.json();
+        setUser({
+          id: data.id,
+          email: data.email,
+          role: data.role,
+          isSuperAdmin: Boolean(data.isSuperAdmin),
+          assessmentId: data.assessmentId || null,
+        });
+      } else {
+        setUser(null);
+      }
+    } catch (error) {
+      console.error("❌ Error refreshing auth:", error);
+      setUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshAuth();
+  }, [refreshAuth]);
+
+  const login = useCallback((userData: AuthUser) => {
+    setUser(userData);
+    setIsLoading(false);
+  }, []);
+
+  const logout = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      await fetch("/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch (error) {
+      console.error("❌ Error during logout:", error);
+    } finally {
+      setUser(null);
+      setIsLoading(false);
+      router.push("/auth/login");
+    }
+  }, [router]);
+
+  const value: AuthContextType = {
+    user,
+    isAdmin: user?.role === 'admin',
+    isSuperAdmin: !!user?.isSuperAdmin,
+    isGrader: user?.role === 'calificador',
+    isRegistrar: user?.role === 'registrador',
+    isAuthenticated: !!user,
+    isLoading,
+    assessmentId: user?.assessmentId || null,
+    login,
+    logout,
+    refreshAuth,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Related work item

Relates to [REQ] Centralización de Autenticación mediante AuthContext Provider

## Summary

Implemented a centralized `AuthContext` and `AuthProvider` to manage session state globally, eliminating redundant API calls to `/api/auth/me`.

## Context

Previously, multiple auth hooks (`useAdminAuth`, `useGraderAuth`, etc.) triggered independent fetch requests, causing performance issues and UI flickers. This change centralizes authentication logic as per ADR 0010.

## Testing

- [x] `npm run lint` passes without new errors
- [x] `npm run build` completes successfully
- [x] `npx vitest run` passes (161 tests passed)
- Manual verification of login/logout flow and session persistence across page navigations.

## Impact

- Refactored all auth hooks to consume the shared context.
- Improved application performance by reducing network traffic.
- Smoother transitions for the `BrandedLoading` component.