### PR TITLE
Refactor/config admin view

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -737,13 +737,16 @@ Obtiene el correo de un calificador por ID.
 Lista participantes registrados en un assessment.
 
 - Auth: admin
+- Notas:
+  - Ignora el `assessmentId` del query param. Utiliza exclusivamente el del token de sesión (JWT).
+  - Si no hay ID en la sesión y el usuario es Superadmin, devuelve 403.
 
 ### POST /api/register
 Inscribe un nuevo participante.
 
 - Auth: admin, registrador
 - Payload (multipart/form-data)
-  - `assessmentId`: number (opcional si el usuario es admin y se usa el de su JWT)
+  - `assessmentId`: number (opcional, se prioriza el del JWT si el usuario es admin)
   - `nombre`: string
   - `correo`: string
   - `isImpostor`: boolean (string "true" / "false" en el form-data)
@@ -991,18 +994,18 @@ Devuelve el resumen de configuración para dashboard administrativo.
 
 - Auth: admin
 - Uso esperado: GET
-- Notas
-  - El código actual acepta assessmentId opcional y usa un assessment por defecto si no se envía.
-  - El handler actual no valida método explícitamente, pero debe consumirse vía GET.
+- Notas:
+  - Utiliza exclusivamente el `assessmentId` de la sesión (JWT).
+  - Ignora cualquier parámetro enviado por URL.
 
 ### GET /api/dashboard/gh?assessmentId=6
 Devuelve la sábana de resultados y promedios por base.
 
 - Auth: admin
 - Uso esperado: GET
-- Notas
-  - El código actual usa assessmentId opcional y cae al assessment por defecto.
-  - El handler actual no valida método explícitamente, pero debe consumirse vía GET.
+- Notas:
+  - Utiliza exclusivamente el `assessmentId` de la sesión (JWT).
+  - Ignora cualquier parámetro enviado por URL.
 
 ### GET /api/dashboard/rotations?assessmentId=6
 Lista las rotaciones de calificadores, incluyendo base y grupo asignados.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,6 +68,27 @@ button:disabled {
 
 /* ============ ANIMACIONES ============ */
 
+/* Shimmer effect for skeleton loaders - Forced Light Mode for now */
+@keyframes shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+.animate-shimmer {
+  background: linear-gradient(
+    90deg,
+    #f3f4f6 25%,
+    rgba(124, 58, 237, 0.1) 50%,
+    #f3f4f6 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 2s linear infinite;
+}
+
 /* Fade in sutil */
 @keyframes fadeIn {
   from {

--- a/src/components/UI/Loading.tsx
+++ b/src/components/UI/Loading.tsx
@@ -64,96 +64,101 @@ export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({
 
 interface SkeletonProps {
   className?: string;
+  index?: number;
 }
 
-export const Skeleton: React.FC<SkeletonProps> = ({ className = '' }) => (
+export const Skeleton: React.FC<SkeletonProps> = ({ className = '', index = 0 }) => (
   <div
-    className={`bg-[color:var(--color-muted)]/20 rounded animate-pulse ${className}`}
+    className={`animate-shimmer rounded ${className}`}
+    style={{ animationDelay: `-${index * 150}ms` }}
     aria-hidden="true"
   />
 );
 
-export const SkeletonText: React.FC<{ lines?: number; className?: string }> = ({
+export const SkeletonText: React.FC<{ lines?: number; className?: string; index?: number }> = ({
   lines = 1,
   className = '',
+  index = 0,
 }) => (
   <div className={`space-y-2 ${className}`}>
     {Array.from({ length: lines }).map((_, i) => (
       <Skeleton
         key={i}
+        index={index + i}
         className={`h-4 ${i === lines - 1 ? 'w-3/4' : 'w-full'}`}
       />
     ))}
   </div>
 );
 
-export const SkeletonAvatar: React.FC<{ size?: 'sm' | 'md' | 'lg' }> = ({
+export const SkeletonAvatar: React.FC<{ size?: 'sm' | 'md' | 'lg'; index?: number }> = ({
   size = 'md',
+  index = 0,
 }) => {
   const sizes = {
     sm: 'w-10 h-10',
     md: 'w-16 h-16',
     lg: 'w-24 h-24',
   };
-  return <Skeleton className={`${sizes[size]} rounded-full`} />;
+  return <Skeleton index={index} className={`${sizes[size]} rounded-full`} />;
 };
 
-export const SkeletonUserCard: React.FC = () => (
+export const SkeletonUserCard: React.FC<{ index?: number }> = ({ index = 0 }) => (
   <div
     className="bg-[color:var(--color-surface)]/60 backdrop-blur-sm rounded-xl p-4 flex flex-col items-center space-y-3 border border-[color:var(--color-muted)]/30"
     style={{ width: '100%', maxWidth: '360px', minHeight: '450px' }}
   >
-    <SkeletonAvatar size="lg" />
-    <Skeleton className="h-4 w-20" />
-    <Skeleton className="h-4 w-32" />
+    <SkeletonAvatar size="lg" index={index} />
+    <Skeleton index={index + 1} className="h-4 w-20" />
+    <Skeleton index={index + 2} className="h-4 w-32" />
     <div className="w-full space-y-4 mt-4">
       {[1, 2, 3].map((i) => (
         <div key={i} className="space-y-2">
-          <Skeleton className="h-3 w-full" />
-          <Skeleton className="h-10 w-full rounded-md" />
+          <Skeleton index={index + 2 + i} className="h-3 w-full" />
+          <Skeleton index={index + 3 + i} className="h-10 w-full rounded-md" />
         </div>
       ))}
     </div>
   </div>
 );
 
-export const SkeletonTableRow: React.FC = () => (
-  <div className="flex items-center space-x-4 p-4 border-b border-white/10">
-    <SkeletonAvatar size="sm" />
+export const SkeletonTableRow: React.FC<{ index?: number }> = ({ index = 0 }) => (
+  <div className="flex items-center space-x-4 p-4 border-b border-gray-100">
+    <SkeletonAvatar size="sm" index={index} />
     <div className="flex-1 space-y-2">
-      <Skeleton className="h-4 w-1/3" />
-      <Skeleton className="h-3 w-1/2" />
+      <Skeleton index={index + 1} className="h-4 w-1/3" />
+      <Skeleton index={index + 2} className="h-3 w-1/2" />
     </div>
-    <Skeleton className="h-8 w-20 rounded-md" />
+    <Skeleton index={index + 3} className="h-8 w-20 rounded-md" />
   </div>
 );
 
-export const SkeletonDashboardCard: React.FC = () => (
+export const SkeletonDashboardCard: React.FC<{ index?: number }> = ({ index = 0 }) => (
   <div
     className="bg-white rounded-lg p-4 flex flex-col items-center border border-gray-100 shadow"
     style={{ width: '100%', maxWidth: '320px', minHeight: '240px' }}
   >
-    <div className="h-5 w-3/4 mb-4 bg-gray-200 rounded" />
+    <Skeleton index={index} className="h-5 w-3/4 mb-4" />
     <div className="h-px w-full mb-4 bg-gray-100" />
     <div className="w-full space-y-2">
-      <div className="h-4 w-1/4 bg-gray-200 rounded" />
-      <div className="h-4 w-1/2 bg-gray-200 rounded" />
-      <div className="h-4 w-2/3 bg-gray-200 rounded" />
-      <div className="h-4 w-1/3 bg-gray-200 rounded" />
-      <div className="h-4 w-1/2 bg-gray-200 rounded" />
+      <Skeleton index={index + 1} className="h-4 w-1/4" />
+      <Skeleton index={index + 2} className="h-4 w-1/2" />
+      <Skeleton index={index + 3} className="h-4 w-2/3" />
+      <Skeleton index={index + 4} className="h-4 w-1/3" />
+      <Skeleton index={index + 5} className="h-4 w-1/2" />
     </div>
   </div>
 );
 
-export const SkeletonBaseInfo: React.FC = () => (
+export const SkeletonBaseInfo: React.FC<{ index?: number }> = ({ index = 0 }) => (
   <div className="w-full max-w-xl mb-6 sm:mb-10 px-4 sm:px-6 py-4 sm:py-6 rounded-2xl bg-[color:var(--color-surface)]/60 backdrop-blur-sm border border-[color:var(--color-muted)]/30">
-    <Skeleton className="h-7 w-1/2 mx-auto mb-4" />
-    <Skeleton className="h-5 w-2/3 mx-auto mb-4" />
-    <SkeletonText lines={3} className="mb-6" />
+    <Skeleton index={index} className="h-7 w-1/2 mx-auto mb-4" />
+    <Skeleton index={index + 1} className="h-5 w-2/3 mx-auto mb-4" />
+    <SkeletonText lines={3} className="mb-6" index={index + 2} />
     <div className="space-y-3">
-      <Skeleton className="h-4 w-full" />
-      <Skeleton className="h-4 w-full" />
-      <Skeleton className="h-4 w-full" />
+      <Skeleton index={index + 5} className="h-4 w-full" />
+      <Skeleton index={index + 6} className="h-4 w-full" />
+      <Skeleton index={index + 7} className="h-4 w-full" />
     </div>
   </div>
 );

--- a/src/features/admin/bases/components/BasesContainer.tsx
+++ b/src/features/admin/bases/components/BasesContainer.tsx
@@ -8,15 +8,17 @@ import { BasesList } from './BasesList';
 import { BaseModal } from './BaseModal';
 import { Button } from '@/components/UI/Button';
 import { notify, NotificationProvider } from '@/components/UI/Notification';
+import { Skeleton } from '@/components/UI/Loading';
 
 export const BasesContainer: React.FC = () => {
   const router = useRouter();
   const { logout } = useAdminAuth();
 
+
   const {
     bases,
     setBases,
-    loading,
+    loading: dataLoading,
   } = useBasesData();
 
   const {
@@ -55,17 +57,41 @@ export const BasesContainer: React.FC = () => {
       />
 
       <div className="w-full max-w-[1200px] mb-6 flex justify-start">
-        <Button variant="accent" onClick={handleOpenCreate}>
-          + Crear Nueva Base
-        </Button>
+        {dataLoading && bases.length === 0 ? (
+          <Skeleton className="h-10 w-44 rounded-lg" />
+        ) : (
+          <Button variant="accent" onClick={handleOpenCreate}>
+            + Crear Nueva Base
+          </Button>
+        )}
       </div>
 
-      <BasesList
-        bases={bases}
-        loading={loading}
-        onOpenEdit={handleOpenEdit}
-        onDelete={handleDelete}
-      />
+      {dataLoading && bases.length === 0 ? (
+        <div className="w-full max-w-[1200px] grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3, 4, 5, 6].map((_, i) => (
+            <div key={i} className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm space-y-4">
+              <div className="flex justify-between items-start">
+                <Skeleton className="h-12 w-12 rounded-xl" index={i} />
+                <Skeleton className="h-8 w-20 rounded-lg" index={i + 1} />
+              </div>
+              <Skeleton className="h-6 w-3/4" index={i + 2} />
+              <Skeleton className="h-4 w-full" index={i + 3} />
+              <Skeleton className="h-4 w-5/6" index={i + 4} />
+              <div className="pt-4 border-t border-gray-50 flex gap-2">
+                <Skeleton className="h-10 flex-1 rounded-xl" index={i + 5} />
+                <Skeleton className="h-10 flex-1 rounded-xl" index={i + 6} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <BasesList
+          bases={bases}
+          loading={dataLoading}
+          onOpenEdit={handleOpenEdit}
+          onDelete={handleDelete}
+        />
+      )}
 
       <BaseModal
         showModal={showModal}

--- a/src/features/admin/configuration/ConfigContainer.tsx
+++ b/src/features/admin/configuration/ConfigContainer.tsx
@@ -4,283 +4,223 @@ import { useAdminAuth } from '@/hooks/useAdminAuth';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { notify, NotificationProvider } from '@/components/UI/Notification';
-import { authFetch } from '@/lib/auth/authFetch';
-
-// Hooks de dominio
-import { useConfigData } from './hooks/useConfigData';
+import { Button } from '@/components/UI/Button';
+import { Box } from '@/components/UI/Box';
+import { BrandedLoading, Skeleton } from '@/components/UI/Loading';
 import { useParticipantsAndGroups } from './hooks/useParticipantsAndGroups';
-import { useBases } from './hooks/useBases';
-import { type Calificacion } from './schemas/configSchemas';
-
-// Componentes de Feature
-import { RegisterStaffForm } from './components/RegisterStaffForm';
+import { useBasesData } from '../bases/hooks/useBasesData';
 import { ParticipantFiltersBar } from './components/ParticipantFiltersBar';
+import { RegisterStaffForm } from './components/RegisterStaffForm';
+import { EditGroupsForm } from './components/EditGroupsForm';
+import { DropdownOverlay } from './components/DropdownOverlay';
+import { useConfirmModal } from '@/components/UI/ConfirmModal';
+import { authFetch } from '@/lib/auth/authFetch';
 import { ParticipantGrid } from './components/ParticipantGrid';
+import { ParticipantCard } from './components/ParticipantCard';
 import { ParticipantPagination } from './components/ParticipantPagination';
 import { EditParticipantModal } from './components/EditParticipantModal';
-import { DropdownOverlay } from './components/DropdownOverlay';
-import { EditGroupsForm } from './components/EditGroupsForm';
-
-// UI Components
-import { Box } from '@/components/UI/Box';
-import { Button } from '@/components/UI/Button';
-import { BrandedLoading } from '@/components/UI/Loading';
 
 export const ConfigContainer = () => {
-  const {
-    isAdmin,
-    assessmentId,
-    isLoading: authLoading,
-    logout,
-  } = useAdminAuth();
+  const { isAdmin, assessmentId, isLoading: authLoading, logout } = useAdminAuth();
   const router = useRouter();
 
-  // Domain Hooks
-  const { data, setData, loading: dataLoading, error: dataError, fetchData } = useConfigData(logout);
-  const { participants, groups, loadParticipantsAndGroups } = useParticipantsAndGroups(logout);
-  const { basesList, loadBases } = useBases(logout);
+  const { staff, participants, groups, loading: dataLoading, loadParticipantsAndGroups } = useParticipantsAndGroups(logout);
+  const { bases } = useBasesData();
 
-  // UI State
-  const [editModal, setEditModal] = useState<Calificacion | null>(null);
-  const [originalData, setOriginalData] = useState<Calificacion | null>(null);
-
+  const [staffCorreo, setStaffCorreo] = useState('');
+  const [staffPassword, setStaffPassword] = useState('');
+  const [staffRol, setStaffRol] = useState('');
+  const [staffBaseId, setStaffBaseId] = useState('');
   const [creatingStaff, setCreatingStaff] = useState(false);
-  const [autoGroupCount, setAutoGroupCount] = useState("");
-  const [autoGrouping, setAutoGrouping] = useState(false);
-  const [staffCorreo, setStaffCorreo] = useState("");
-  const [staffPassword, setStaffPassword] = useState("");
-  const [staffRol, setStaffRol] = useState("");
-  const [staffBaseId, setStaffBaseId] = useState("");
 
   const [showAutoGroupDropdown, setShowAutoGroupDropdown] = useState(false);
+  const [autoGroupCount, setAutoGroupCount] = useState('');
+  const [autoGrouping, setAutoGrouping] = useState(false);
+
   const [showEditGroupsDropdown, setShowEditGroupsDropdown] = useState(false);
 
   const [searchTerm, setSearchTerm] = useState("");
-  const [filterRol, setFilterRol] = useState<string>("todos");
+  const [filterRol, setFilterRol] = useState("todos");
   const [sortBy, setSortBy] = useState<"nombre" | "rol">("nombre");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 12;
+  const [itemsPerPage] = useState(10);
 
-  useEffect(() => {
-    if (!authLoading && !isAdmin) {
-      router.push("/auth/login");
-    }
-  }, [authLoading, isAdmin, router]);
+  const [editModal, setEditModal] = useState<{
+    id: number;
+    correo: string;
+    role: string;
+    active: boolean;
+  } | null>(null);
+  const [originalData, setOriginalData] = useState<{
+    correo: string;
+    role: string;
+    active: boolean;
+  } | null>(null);
+
+  const { ConfirmModalComponent } = useConfirmModal();
 
   useEffect(() => {
     if (authLoading || !isAdmin) return;
-    
     const loadAllData = async () => {
       await Promise.all([
-        fetchData(),
-        loadParticipantsAndGroups(),
-        loadBases()
+        loadParticipantsAndGroups()
       ]);
     };
-
     loadAllData();
-  }, [authLoading, isAdmin, fetchData, loadParticipantsAndGroups, loadBases]);
+  }, [authLoading, isAdmin, loadParticipantsAndGroups]);
 
   const filteredAndSortedData = useMemo(() => {
-    const filtered = data.filter((item) => {
-      const matchSearch = item.Correo.toLowerCase().includes(searchTerm.toLowerCase());
-      const matchRol = filterRol === "todos" || item.role === filterRol;
-      return matchSearch && matchRol;
+    const results = staff.filter((s) => {
+      const matchesSearch = s.Correo.toLowerCase().includes(searchTerm.toLowerCase());
+      const matchesRol = filterRol === "todos" || s.role === filterRol;
+      return matchesSearch && matchesRol;
     });
 
-    filtered.sort((a, b) => {
+    return results.sort((a, b) => {
       let comparison = 0;
-      switch (sortBy) {
-        case "nombre":
-          comparison = a.Correo.localeCompare(b.Correo);
-          break;
-        case "rol":
-          comparison = a.role.localeCompare(b.role);
-          break;
-      }
+      if (sortBy === "nombre") comparison = a.Correo.localeCompare(b.Correo);
+      else if (sortBy === "rol") comparison = a.role.localeCompare(b.role);
       return sortOrder === "asc" ? comparison : -comparison;
     });
-
-    return filtered;
-  }, [data, searchTerm, filterRol, sortBy, sortOrder]);
-
-  const totalPages = Math.max(1, Math.ceil(filteredAndSortedData.length / itemsPerPage));
-
-  useEffect(() => {
-    if (currentPage > totalPages) {
-      setCurrentPage(totalPages);
-    }
-  }, [totalPages, currentPage]);
+  }, [staff, searchTerm, filterRol, sortBy, sortOrder]);
 
   const paginatedData = useMemo(() => {
-    const startIndex = (currentPage - 1) * itemsPerPage;
-    return filteredAndSortedData.slice(startIndex, startIndex + itemsPerPage);
+    const start = (currentPage - 1) * itemsPerPage;
+    return filteredAndSortedData.slice(start, start + itemsPerPage);
   }, [filteredAndSortedData, currentPage, itemsPerPage]);
 
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchTerm, filterRol]);
-
-  const handleUpdate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!editModal || !originalData) return;
-
-    const updates: Record<string, any> = { id: editModal.ID };
-    if (editModal.Correo !== originalData.Correo) updates.correo = editModal.Correo;
-    if (editModal.role !== originalData.role) updates.role = editModal.role;
-    if (editModal.Active !== originalData.Active) updates.active = editModal.Active;
-
-    if (Object.keys(updates).length === 1) {
-      notify({
-        title: 'Sin cambios',
-        titleColor: 'var(--error)',
-        subtitle: 'Debe modificarse al menos un campo',
-        subtitleColor: 'var(--color-muted)',
-        borderColor: 'var(--error)',
-        duration: 1500,
-      });
-      return;
-    }
-
-    const res = await authFetch(
-      '/api/staff/update-active',
-      {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(updates),
-      },
-      () => logout()
-    );
-
-    const result = await res.json();
-    if (res.ok) {
-      notify({
-        title: 'Staff actualizado',
-        titleColor: 'var(--color-accent)',
-        subtitle: 'Staff actualizado correctamente',
-        subtitleColor: 'var(--color-muted)',
-        borderColor: 'var(--color-accent)',
-        duration: 1500,
-      });
-      setData((prev) => prev.map((p) => (p.ID === editModal.ID ? editModal : p)));
-      setEditModal(null);
-      setOriginalData(null);
-    } else {
-      notify({
-        title: 'Error al actualizar',
-        titleColor: 'var(--error)',
-        subtitle: result.error || 'Error al actualizar',
-        subtitleColor: 'var(--color-muted)',
-        borderColor: 'var(--error)',
-        duration: 1500,
-      });
-    }
-  };
+  const totalPages = Math.ceil(filteredAndSortedData.length / itemsPerPage);
 
   const handleCreateStaff = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!staffCorreo || !staffPassword || !staffRol) {
       notify({
         title: 'Campos incompletos',
-        titleColor: 'var(--error)',
-        subtitle: 'Todos los campos obligatorios deben completarse',
+        titleColor: 'var(--warning)',
+        subtitle: 'Por favor completa todos los campos obligatorios',
         subtitleColor: 'var(--color-muted)',
-        borderColor: 'var(--error)',
-        duration: 2000,
-      });
-      return;
-    }
-    if (staffRol === 'calificador' && !staffBaseId) {
-      notify({
-        title: 'Base requerida',
-        titleColor: 'var(--error)',
-        subtitle: 'Los calificadores deben tener una base asignada',
-        subtitleColor: 'var(--color-muted)',
-        borderColor: 'var(--error)',
-        duration: 2000,
+        borderColor: 'var(--warning)',
+        duration: 3000,
       });
       return;
     }
 
+    setCreatingStaff(true);
     try {
-      setCreatingStaff(true);
-      const response = await authFetch(
-        '/api/staff/create',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            correo: staffCorreo.trim(),
-            password: staffPassword,
-            rol: staffRol,
-            idBase: staffRol === 'calificador' && staffBaseId ? Number(staffBaseId) : null,
-          }),
-        },
-        () => logout()
-      );
+      const response = await authFetch('/api/staff/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          correo: staffCorreo,
+          password: staffPassword,
+          rol: staffRol,
+          idBase: staffRol === 'calificador' ? Number(staffBaseId) : null,
+        }),
+      }, () => logout());
 
-      const result = await response.json();
-      if (!response.ok) throw new Error(result.error || 'Error al crear staff');
-
+      if (response.ok) {
+        notify({
+          title: 'Staff registrado',
+          titleColor: 'var(--color-accent)',
+          subtitle: 'El miembro del staff ha sido creado exitosamente',
+          subtitleColor: 'var(--color-muted)',
+          borderColor: 'var(--color-accent)',
+          duration: 3000,
+        });
+        setStaffCorreo('');
+        setStaffPassword('');
+        setStaffRol('');
+        setStaffBaseId('');
+        await loadParticipantsAndGroups();
+      } else {
+        const error = await response.json();
+        notify({
+          title: 'Error al registrar',
+          titleColor: 'var(--error)',
+          subtitle: error.error || 'No se pudo completar el registro',
+          subtitleColor: 'var(--color-muted)',
+          borderColor: 'var(--error)',
+          duration: 4000,
+        });
+      }
+    } catch {
       notify({
-        title: staffRol === 'calificador' ? 'Calificador creado' : 'Registrador creado',
-        titleColor: 'var(--color-accent)',
-        subtitle: `${staffRol === 'calificador' ? 'Calificador' : 'Registrador'} creado correctamente`,
-        subtitleColor: 'var(--color-muted)',
-        borderColor: 'var(--color-accent)',
-        duration: 2000,
-      });
-      setStaffCorreo('');
-      setStaffPassword('');
-      setStaffRol('');
-      setStaffBaseId('');
-    } catch (err: unknown) {
-      notify({
-        title: 'Error al crear staff',
+        title: 'Error de red',
         titleColor: 'var(--error)',
-        subtitle: err instanceof Error ? err.message : 'Error al crear staff',
+        subtitle: 'No se pudo conectar con el servidor',
         subtitleColor: 'var(--color-muted)',
         borderColor: 'var(--error)',
-        duration: 1500,
+        duration: 4000,
       });
     } finally {
       setCreatingStaff(false);
     }
   };
 
-  const handleAutoGroup = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const numGroups = Number(autoGroupCount);
-    if (!autoGroupCount || Number.isNaN(numGroups) || numGroups <= 0) {
-      notify({
-        title: 'Cantidad invalida',
-        titleColor: 'var(--error)',
-        subtitle: 'Ingresa una cantidad valida de grupos',
-        subtitleColor: 'var(--color-muted)',
-        borderColor: 'var(--error)',
-        duration: 2000,
-      });
+  const handleUpdateStaff = async () => {
+    if (!editModal) return;
+    const isNoChange = 
+      editModal.correo === originalData?.correo &&
+      editModal.role === originalData?.role &&
+      editModal.active === originalData?.active;
+
+    if (isNoChange) {
+      setEditModal(null);
       return;
     }
 
     try {
-      setAutoGrouping(true);
-      const response = await authFetch(
-        '/api/assessment/auto-groups',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ numGroups }),
-        },
-        () => logout()
-      );
+      const response = await authFetch('/api/staff/update-active', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: editModal.id,
+          correo: editModal.correo,
+          role: editModal.role,
+          active: editModal.active,
+        }),
+      }, () => logout());
 
-      const result = await response.json();
-      if (!response.ok) throw new Error(result.error || 'Error al sortear grupos');
+      if (response.ok) {
+        notify({
+          title: 'Staff actualizado',
+          titleColor: 'var(--color-accent)',
+          subtitle: 'Los cambios se guardaron correctamente',
+          subtitleColor: 'var(--color-muted)',
+          borderColor: 'var(--color-accent)',
+          duration: 3000,
+        });
+        setEditModal(null);
+        setOriginalData(null);
+        await loadParticipantsAndGroups();
+      }
+    } catch (err) {
+      console.error('Error updating staff:', err);
+    }
+  };
+
+  const handleAutoGroup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!autoGroupCount || autoGrouping) return;
+
+    setAutoGrouping(true);
+    try {
+      const response = await authFetch('/api/assessment/auto-groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          numGroups: Number(autoGroupCount),
+        }),
+      }, () => logout());
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Error al sortear');
+      }
 
       notify({
-        title: 'Grupos creados',
+        title: 'Sorteo Exitoso',
         titleColor: 'var(--color-accent)',
         subtitle: 'Grupos creados y sorteados correctamente',
         subtitleColor: 'var(--color-muted)',
@@ -289,7 +229,6 @@ export const ConfigContainer = () => {
       });
       setAutoGroupCount('');
       setShowAutoGroupDropdown(false);
-      await fetchData();
       await loadParticipantsAndGroups();
     } catch (err: unknown) {
       notify({
@@ -305,21 +244,9 @@ export const ConfigContainer = () => {
     }
   };
 
-  if (authLoading || dataLoading) {
-    return <BrandedLoading message="Preparando configuracion del panel..." />;
-  }
+  if (authLoading) return <BrandedLoading message="Preparando panel..." />;
 
-  if (dataError) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-white">
-        <p className="text-error text-xl">{dataError}</p>
-        <Button variant="outline" onClick={() => router.refresh()} className="mt-4">
-          Reintentar
-        </Button>
-      </div>
-    );
-  }
-
+  // Los spinners internos usarán dataLoading para feedback.
   return (
     <div className="flex flex-col items-center min-h-screen py-4 sm:py-8 px-3 sm:px-4 bg-white">
       <div className="w-full max-w-[900px] flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4 px-1 sm:px-2">
@@ -329,13 +256,69 @@ export const ConfigContainer = () => {
         <div className="flex flex-wrap items-center justify-center sm:justify-end gap-2">
           <Button variant="accent" onClick={() => router.push("/admin")}>
             <Image src="/HomeIcon.svg" alt="" width={18} height={18} className="mr-2" />
-            Menu principal
+            Menú principal
           </Button>
           <Button variant="error" onClick={logout}>
             <Image src="/LogoutIcon.svg" alt="" width={18} height={18} className="mr-2" />
-            Cerrar Sesion
+            Cerrar Sesión
           </Button>
         </div>
+      </div>
+
+      <div className="w-full max-w-[900px] mb-4 px-1 sm:px-2">
+        <Box className="p-4 sm:p-6">
+          <div className="flex justify-between items-center mb-6">
+            {dataLoading && staff.length === 0 ? (
+              <Skeleton className="h-7 w-48" />
+            ) : (
+              <h2 className="text-lg font-bold text-gray-900">Ajustes de grupo</h2>
+            )}
+            
+            <div className="flex gap-2">
+              {dataLoading && staff.length === 0 ? (
+                <>
+                  <Skeleton className="h-10 w-32 rounded-lg" />
+                  <Skeleton className="h-10 w-32 rounded-lg" />
+                </>
+              ) : (
+                <>
+                  <Button variant="accent" onClick={() => setShowAutoGroupDropdown(true)}>
+                    Crear y sortear
+                  </Button>
+                  <Button variant="outline" onClick={() => setShowEditGroupsDropdown(true)}>
+                    Editar grupos
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+
+          {dataLoading && staff.length === 0 ? (
+            <div className="space-y-4">
+              <Skeleton className="h-12 w-full rounded-xl" />
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Skeleton className="h-24 w-full rounded-xl" />
+                <Skeleton className="h-24 w-full rounded-xl" />
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-500">
+                Administra la estructura de grupos del assessment. Puedes realizar un sorteo automático repartiendo impostores o gestionar integrantes manualmente.
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="bg-gray-50 border border-gray-100 rounded-xl p-4 flex flex-col items-center justify-center text-center">
+                  <span className="text-2xl font-bold text-gray-900">{groups.length}</span>
+                  <span className="text-xs text-gray-500 uppercase tracking-wider font-semibold">Grupos Creados</span>
+                </div>
+                <div className="bg-gray-50 border border-gray-100 rounded-xl p-4 flex flex-col items-center justify-center text-center">
+                  <span className="text-2xl font-bold text-gray-900">{participants.filter(p => !p.grupoId).length}</span>
+                  <span className="text-xs text-gray-500 uppercase tracking-wider font-semibold">Participantes sin grupo</span>
+                </div>
+              </div>
+            </div>
+          )}
+        </Box>
       </div>
 
       <RegisterStaffForm
@@ -347,33 +330,10 @@ export const ConfigContainer = () => {
         setStaffRol={setStaffRol}
         staffBaseId={staffBaseId}
         setStaffBaseId={setStaffBaseId}
-        basesList={basesList}
+        basesList={bases}
         creatingStaff={creatingStaff}
         onSubmit={handleCreateStaff}
       />
-
-      {/* Ajustes de grupo */}
-      <div className="w-full max-w-[900px] mb-4 px-1 sm:px-2">
-        <Box className="p-4">
-          <h2 className="text-lg font-bold text-gray-900 mb-4 text-center sm:text-left">Ajustes de grupo</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <Button
-              onClick={() => setShowEditGroupsDropdown(true)}
-              className="w-full py-3 h-auto text-base font-bold"
-              variant="accent"
-            >
-              Editar grupos
-            </Button>
-            <Button
-              onClick={() => setShowAutoGroupDropdown(true)}
-              className="w-full py-3 h-auto text-base font-bold"
-              variant="accent"
-            >
-              Crear y sortear grupos
-            </Button>
-          </div>
-        </Box>
-      </div>
 
       <DropdownOverlay
         isOpen={showAutoGroupDropdown}
@@ -412,8 +372,6 @@ export const ConfigContainer = () => {
         title="Editar Grupos"
         wide
         confirmLabel="Confirmar edicion"
-        cancelNotifyTitle="Edicion cancelada"
-        cancelNotifySubtitle="No se guardaron cambios en los grupos"
         onConfirm={() => {
           notify({
             title: 'Grupos actualizados',
@@ -431,8 +389,7 @@ export const ConfigContainer = () => {
           participants={participants}
           assessmentId={assessmentId || 0}
           onRefresh={async () => {
-            await fetchData(true);
-            await loadParticipantsAndGroups(true);
+            await loadParticipantsAndGroups();
           }}
           logout={logout}
         />
@@ -455,27 +412,80 @@ export const ConfigContainer = () => {
           <span>Mostrando {paginatedData.length} de {filteredAndSortedData.length} resultados</span>
         </div>
 
-        <ParticipantGrid
-          paginatedData={paginatedData}
-          onEdit={(p) => { setEditModal({ ...p }); setOriginalData({ ...p }); }}
-        />
-
-        <ParticipantPagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          setCurrentPage={setCurrentPage}
-        />
+        <Box className="w-full !p-0 overflow-hidden">
+          {dataLoading && staff.length === 0 ? (
+            <div className="p-4 space-y-4">
+              {[1, 2, 3, 4, 5].map((_, i) => (
+                <div key={i} className="flex items-center gap-4">
+                  <Skeleton className="h-10 w-10 rounded-full" index={i} />
+                  <Skeleton className="h-4 flex-1" index={i + 1} />
+                  <Skeleton className="h-8 w-20 rounded-lg" index={i + 2} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <>
+              {/* Para prop paginatedData, pasamos staff formateado si es necesario */}
+              <ParticipantGrid
+                paginatedData={paginatedData.map(s => ({
+                  ID: s.ID,
+                  Participante: s.Correo.split('@')[0],
+                  Correo: s.Correo,
+                  role: s.role,
+                  Grupo: '', // Staff no tiene grupo
+                  Calificacion_Promedio: null,
+                  Estado: '',
+                  Active: s.Active
+                }))}
+                onEdit={(item) => {
+                  const s = staff.find(x => x.ID === item.ID);
+                  if (s) {
+                    setEditModal({
+                      id: s.ID,
+                      correo: s.Correo,
+                      role: s.role,
+                      active: s.Active
+                    });
+                    setOriginalData({ correo: s.Correo, role: s.role, active: s.Active });
+                  }
+                }}
+              />
+              {totalPages > 1 && (
+                <div className="p-4 border-t border-gray-100 flex justify-center">
+                  <ParticipantPagination
+                    currentPage={currentPage}
+                    totalPages={totalPages}
+                    setCurrentPage={setCurrentPage}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </Box>
       </div>
 
       {editModal && (
         <EditParticipantModal
-          editModal={editModal}
-          setEditModal={setEditModal}
+          editModal={{
+            ID: editModal.id,
+            Participante: editModal.correo.split('@')[0],
+            Correo: editModal.correo,
+            role: editModal.role,
+            Active: editModal.active,
+            Grupo: '',
+            Calificacion_Promedio: null,
+            Estado: ''
+          }}
+          setEditModal={(val) => {
+            if (!val) setEditModal(null);
+            else setEditModal({ id: val.ID, correo: val.Correo, role: val.role, active: !!val.Active });
+          }}
           onCancel={() => { setEditModal(null); setOriginalData(null); }}
-          onUpdate={handleUpdate}
+          onUpdate={handleUpdateStaff}
         />
       )}
 
+      <ConfirmModalComponent />
       <NotificationProvider />
     </div>
   );

--- a/src/features/admin/configuration/ConfigContainer.tsx
+++ b/src/features/admin/configuration/ConfigContainer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { useAdminAuth } from '@/hooks/useAdminAuth';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
-import { showToast } from '@/components/UI/Toast';
+import { notify, NotificationProvider } from '@/components/UI/Notification';
 import { authFetch } from '@/lib/auth/authFetch';
 
 // Hooks de dominio
@@ -24,7 +24,7 @@ import { EditGroupsForm } from './components/EditGroupsForm';
 // UI Components
 import { Box } from '@/components/UI/Box';
 import { Button } from '@/components/UI/Button';
-import { Spinner, BrandedLoading } from '@/components/UI/Loading';
+import { BrandedLoading } from '@/components/UI/Loading';
 
 export const ConfigContainer = () => {
   const {
@@ -43,7 +43,7 @@ export const ConfigContainer = () => {
   // UI State
   const [editModal, setEditModal] = useState<Calificacion | null>(null);
   const [originalData, setOriginalData] = useState<Calificacion | null>(null);
-  
+
   const [creatingStaff, setCreatingStaff] = useState(false);
   const [autoGroupCount, setAutoGroupCount] = useState("");
   const [autoGrouping, setAutoGrouping] = useState(false);
@@ -55,7 +55,6 @@ export const ConfigContainer = () => {
   const [showAutoGroupDropdown, setShowAutoGroupDropdown] = useState(false);
   const [showEditGroupsDropdown, setShowEditGroupsDropdown] = useState(false);
 
-  // Estados para búsqueda, filtros, orden y paginación
   const [searchTerm, setSearchTerm] = useState("");
   const [filterRol, setFilterRol] = useState<string>("todos");
   const [sortBy, setSortBy] = useState<"nombre" | "rol">("nombre");
@@ -85,8 +84,7 @@ export const ConfigContainer = () => {
 
   const filteredAndSortedData = useMemo(() => {
     const filtered = data.filter((item) => {
-      const matchSearch =
-        item.Correo.toLowerCase().includes(searchTerm.toLowerCase());
+      const matchSearch = item.Correo.toLowerCase().includes(searchTerm.toLowerCase());
       const matchRol = filterRol === "todos" || item.role === filterRol;
       return matchSearch && matchRol;
     });
@@ -108,7 +106,7 @@ export const ConfigContainer = () => {
   }, [data, searchTerm, filterRol, sortBy, sortOrder]);
 
   const totalPages = Math.max(1, Math.ceil(filteredAndSortedData.length / itemsPerPage));
-  
+
   useEffect(() => {
     if (currentPage > totalPages) {
       setCurrentPage(totalPages);
@@ -134,7 +132,14 @@ export const ConfigContainer = () => {
     if (editModal.Active !== originalData.Active) updates.active = editModal.Active;
 
     if (Object.keys(updates).length === 1) {
-      showToast.error("Debe modificarse al menos un campo");
+      notify({
+        title: 'Sin cambios',
+        titleColor: 'var(--error)',
+        subtitle: 'Debe modificarse al menos un campo',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--error)',
+        duration: 1500,
+      });
       return;
     }
 
@@ -150,25 +155,51 @@ export const ConfigContainer = () => {
 
     const result = await res.json();
     if (res.ok) {
-      showToast.success("Staff actualizado correctamente");
-      setData((prev) =>
-        prev.map((p) => (p.ID === editModal.ID ? editModal : p))
-      );
+      notify({
+        title: 'Staff actualizado',
+        titleColor: 'var(--color-accent)',
+        subtitle: 'Staff actualizado correctamente',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--color-accent)',
+        duration: 1500,
+      });
+      setData((prev) => prev.map((p) => (p.ID === editModal.ID ? editModal : p)));
       setEditModal(null);
       setOriginalData(null);
     } else {
-      showToast.error(result.error || "Error al actualizar");
+      notify({
+        title: 'Error al actualizar',
+        titleColor: 'var(--error)',
+        subtitle: result.error || 'Error al actualizar',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--error)',
+        duration: 1500,
+      });
     }
   };
 
   const handleCreateStaff = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!staffCorreo || !staffPassword || !staffRol) {
-      showToast.error('Todos los campos obligatorios deben completarse');
+      notify({
+        title: 'Campos incompletos',
+        titleColor: 'var(--error)',
+        subtitle: 'Todos los campos obligatorios deben completarse',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--error)',
+        duration: 2000,
+      });
       return;
     }
     if (staffRol === 'calificador' && !staffBaseId) {
-      showToast.error('Los calificadores deben tener una base asignada');
+      notify({
+        title: 'Base requerida',
+        titleColor: 'var(--error)',
+        subtitle: 'Los calificadores deben tener una base asignada',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--error)',
+        duration: 2000,
+      });
       return;
     }
 
@@ -192,13 +223,27 @@ export const ConfigContainer = () => {
       const result = await response.json();
       if (!response.ok) throw new Error(result.error || 'Error al crear staff');
 
-      showToast.success(`${staffRol === 'calificador' ? 'Calificador' : 'Registrador'} creado`);
+      notify({
+        title: staffRol === 'calificador' ? 'Calificador creado' : 'Registrador creado',
+        titleColor: 'var(--color-accent)',
+        subtitle: `${staffRol === 'calificador' ? 'Calificador' : 'Registrador'} creado correctamente`,
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--color-accent)',
+        duration: 2000,
+      });
       setStaffCorreo('');
       setStaffPassword('');
       setStaffRol('');
       setStaffBaseId('');
     } catch (err: unknown) {
-      showToast.error(err instanceof Error ? err.message : 'Error al crear staff');
+      notify({
+        title: 'Error al crear staff',
+        titleColor: 'var(--error)',
+        subtitle: err instanceof Error ? err.message : 'Error al crear staff',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--error)',
+        duration: 1500,
+      });
     } finally {
       setCreatingStaff(false);
     }
@@ -208,7 +253,14 @@ export const ConfigContainer = () => {
     e.preventDefault();
     const numGroups = Number(autoGroupCount);
     if (!autoGroupCount || Number.isNaN(numGroups) || numGroups <= 0) {
-      showToast.error('Ingresa una cantidad válida de grupos');
+      notify({
+        title: 'Cantidad invalida',
+        titleColor: 'var(--error)',
+        subtitle: 'Ingresa una cantidad valida de grupos',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--error)',
+        duration: 2000,
+      });
       return;
     }
 
@@ -219,9 +271,7 @@ export const ConfigContainer = () => {
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            numGroups,
-          }),
+          body: JSON.stringify({ numGroups }),
         },
         () => logout()
       );
@@ -229,32 +279,43 @@ export const ConfigContainer = () => {
       const result = await response.json();
       if (!response.ok) throw new Error(result.error || 'Error al sortear grupos');
 
-      showToast.success('Grupos creados y sorteados correctamente');
+      notify({
+        title: 'Grupos creados',
+        titleColor: 'var(--color-accent)',
+        subtitle: 'Grupos creados y sorteados correctamente',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--color-accent)',
+        duration: 2000,
+      });
       setAutoGroupCount('');
       setShowAutoGroupDropdown(false);
       await fetchData();
       await loadParticipantsAndGroups();
     } catch (err: unknown) {
-      showToast.error(err instanceof Error ? err.message : 'Error al sortear grupos');
+      notify({
+        title: 'Error al sortear grupos',
+        titleColor: 'var(--error)',
+        subtitle: err instanceof Error ? err.message : 'Error al sortear grupos',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--error)',
+        duration: 1500,
+      });
     } finally {
       setAutoGrouping(false);
     }
   };
 
   if (authLoading || dataLoading) {
-    return <BrandedLoading message="Preparando configuración del panel..." />;
+    return <BrandedLoading message="Preparando configuracion del panel..." />;
   }
-  
+
   if (dataError) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-white">
         <p className="text-error text-xl">{dataError}</p>
-        <button 
-          onClick={() => router.refresh()}
-          className="mt-4 px-4 py-2 bg-gray-100 text-gray-900 rounded-lg border border-gray-200 hover:bg-gray-200"
-        >
+        <Button variant="outline" onClick={() => router.refresh()} className="mt-4">
           Reintentar
-        </button>
+        </Button>
       </div>
     );
   }
@@ -262,15 +323,17 @@ export const ConfigContainer = () => {
   return (
     <div className="flex flex-col items-center min-h-screen py-4 sm:py-8 px-3 sm:px-4 bg-white">
       <div className="w-full max-w-[900px] flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4 px-1 sm:px-2">
-        <h1 className="text-2xl sm:text-3xl font-extrabold text-gray-900 text-center sm:text-left">Configuración del Assessment</h1>
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-[color:var(--color-accent)]">
+          Configuracion del Assessment
+        </h1>
         <div className="flex flex-wrap items-center justify-center sm:justify-end gap-2">
           <Button variant="accent" onClick={() => router.push("/admin")}>
             <Image src="/HomeIcon.svg" alt="" width={18} height={18} className="mr-2" />
-            Menú principal
+            Menu principal
           </Button>
           <Button variant="error" onClick={logout}>
             <Image src="/LogoutIcon.svg" alt="" width={18} height={18} className="mr-2" />
-            Cerrar Sesión
+            Cerrar Sesion
           </Button>
         </div>
       </div>
@@ -289,7 +352,7 @@ export const ConfigContainer = () => {
         onSubmit={handleCreateStaff}
       />
 
-      {/* Ajustes de grupo Section */}
+      {/* Ajustes de grupo */}
       <div className="w-full max-w-[900px] mb-4 px-1 sm:px-2">
         <Box className="p-4">
           <h2 className="text-lg font-bold text-gray-900 mb-4 text-center sm:text-left">Ajustes de grupo</h2>
@@ -347,14 +410,29 @@ export const ConfigContainer = () => {
         isOpen={showEditGroupsDropdown}
         onClose={() => setShowEditGroupsDropdown(false)}
         title="Editar Grupos"
+        wide
+        confirmLabel="Confirmar edicion"
+        cancelNotifyTitle="Edicion cancelada"
+        cancelNotifySubtitle="No se guardaron cambios en los grupos"
+        onConfirm={() => {
+          notify({
+            title: 'Grupos actualizados',
+            titleColor: 'var(--color-accent)',
+            subtitle: 'Los cambios en los grupos fueron guardados',
+            subtitleColor: 'var(--color-muted)',
+            borderColor: 'var(--color-accent)',
+            duration: 2000,
+          });
+          setShowEditGroupsDropdown(false);
+        }}
       >
         <EditGroupsForm
           groups={groups}
           participants={participants}
           assessmentId={assessmentId || 0}
           onRefresh={async () => {
-            await fetchData(true); // Silent refresh
-            await loadParticipantsAndGroups(true); // Silent refresh
+            await fetchData(true);
+            await loadParticipantsAndGroups(true);
           }}
           logout={logout}
         />
@@ -375,11 +453,8 @@ export const ConfigContainer = () => {
       <div className="w-full max-w-[900px] flex flex-col items-center">
         <div className="w-full flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 text-gray-500 text-xs mb-2 px-4">
           <span>Mostrando {paginatedData.length} de {filteredAndSortedData.length} resultados</span>
-          {(searchTerm || filterRol !== "todos") && (
-            <button onClick={() => { setSearchTerm(""); setFilterRol("todos"); }} className="text-[color:var(--color-accent)] hover:text-gray-500 underline">Limpiar filtros</button>
-          )}
         </div>
-        
+
         <ParticipantGrid
           paginatedData={paginatedData}
           onEdit={(p) => { setEditModal({ ...p }); setOriginalData({ ...p }); }}
@@ -400,6 +475,8 @@ export const ConfigContainer = () => {
           onUpdate={handleUpdate}
         />
       )}
+
+      <NotificationProvider />
     </div>
   );
 };

--- a/src/features/admin/configuration/components/DropdownOverlay.tsx
+++ b/src/features/admin/configuration/components/DropdownOverlay.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { Button } from '@/components/UI/Button';
-import { notify } from '@/components/UI/Notification';
 
 interface DropdownOverlayProps {
   isOpen: boolean;
@@ -11,8 +10,6 @@ interface DropdownOverlayProps {
   confirmLabel?: string;
   confirmDisabled?: boolean;
   wide?: boolean;
-  cancelNotifyTitle?: string;
-  cancelNotifySubtitle?: string;
 }
 
 export const DropdownOverlay: React.FC<DropdownOverlayProps> = ({
@@ -24,12 +21,12 @@ export const DropdownOverlay: React.FC<DropdownOverlayProps> = ({
   confirmLabel = "Confirmar",
   confirmDisabled = false,
   wide = false,
-  cancelNotifyTitle = "Accion cancelada",
-  cancelNotifySubtitle = "No se realizaron cambios",
 }) => {
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
     }
     return () => {
       document.body.style.overflow = '';
@@ -38,18 +35,6 @@ export const DropdownOverlay: React.FC<DropdownOverlayProps> = ({
 
   if (!isOpen) return null;
 
-  const handleCancel = () => {
-    notify({
-      title: cancelNotifyTitle,
-      titleColor: 'var(--error)',
-      subtitle: cancelNotifySubtitle,
-      subtitleColor: 'var(--color-muted)',
-      borderColor: 'var(--error)',
-      duration: 3000,
-    });
-    onClose();
-  };
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200">
       <div className={`relative w-full ${wide ? 'max-w-2xl' : 'max-w-lg'} bg-white rounded-2xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]`}>
@@ -57,7 +42,7 @@ export const DropdownOverlay: React.FC<DropdownOverlayProps> = ({
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
           <h2 className="text-xl font-bold text-gray-900">{title}</h2>
-          <Button variant="error" onClick={handleCancel} className="!px-3 !py-1 text-base font-bold">
+          <Button variant="error" onClick={onClose} className="!px-3 !py-1 text-base font-bold">
             X
           </Button>
         </div>
@@ -69,7 +54,7 @@ export const DropdownOverlay: React.FC<DropdownOverlayProps> = ({
 
         {/* Footer — siempre visible */}
         <div className="p-6 border-t border-gray-100 flex gap-4">
-          <Button variant="error" onClick={handleCancel} className="flex-1">
+          <Button variant="error" onClick={onClose} className="flex-1">
             Cancelar
           </Button>
           {onConfirm && (

--- a/src/features/admin/configuration/components/DropdownOverlay.tsx
+++ b/src/features/admin/configuration/components/DropdownOverlay.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { Button } from '@/components/UI/Button';
+import { notify } from '@/components/UI/Notification';
 
 interface DropdownOverlayProps {
   isOpen: boolean;
@@ -8,6 +10,9 @@ interface DropdownOverlayProps {
   onConfirm?: () => void;
   confirmLabel?: string;
   confirmDisabled?: boolean;
+  wide?: boolean;
+  cancelNotifyTitle?: string;
+  cancelNotifySubtitle?: string;
 }
 
 export const DropdownOverlay: React.FC<DropdownOverlayProps> = ({
@@ -18,23 +23,43 @@ export const DropdownOverlay: React.FC<DropdownOverlayProps> = ({
   onConfirm,
   confirmLabel = "Confirmar",
   confirmDisabled = false,
+  wide = false,
+  cancelNotifyTitle = "Accion cancelada",
+  cancelNotifySubtitle = "No se realizaron cambios",
 }) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
+
+  const handleCancel = () => {
+    notify({
+      title: cancelNotifyTitle,
+      titleColor: 'var(--error)',
+      subtitle: cancelNotifySubtitle,
+      subtitleColor: 'var(--color-muted)',
+      borderColor: 'var(--error)',
+      duration: 3000,
+    });
+    onClose();
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200">
-      <div className="relative w-full max-w-lg bg-white rounded-2xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]">
+      <div className={`relative w-full ${wide ? 'max-w-2xl' : 'max-w-lg'} bg-white rounded-2xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]`}>
+
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
           <h2 className="text-xl font-bold text-gray-900">{title}</h2>
-          <button
-            onClick={onClose}
-            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition"
-          >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <Button variant="error" onClick={handleCancel} className="!px-3 !py-1 text-base font-bold">
+            X
+          </Button>
         </div>
 
         {/* Content */}
@@ -42,22 +67,21 @@ export const DropdownOverlay: React.FC<DropdownOverlayProps> = ({
           {children}
         </div>
 
-        {/* Footer */}
+        {/* Footer — siempre visible */}
         <div className="p-6 border-t border-gray-100 flex gap-4">
-          <button
-            onClick={onClose}
-            className="flex-1 px-4 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 font-semibold rounded-xl transition"
-          >
+          <Button variant="error" onClick={handleCancel} className="flex-1">
             Cancelar
-          </button>
+          </Button>
           {onConfirm && (
-            <button
+            <Button
+              variant="accent"
               onClick={onConfirm}
               disabled={confirmDisabled}
-              className="flex-1 px-4 py-3 bg-[color:var(--color-accent)] hover:bg-[#5B21B6] disabled:opacity-50 text-white font-semibold rounded-xl transition shadow-lg shadow-purple-200"
+              loading={confirmDisabled}
+              className="flex-1"
             >
               {confirmLabel}
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/src/features/admin/configuration/components/EditGroupsForm.tsx
+++ b/src/features/admin/configuration/components/EditGroupsForm.tsx
@@ -4,7 +4,7 @@ import { authFetch } from '@/lib/auth/authFetch';
 import { notify } from '@/components/UI/Notification';
 import { useConfirmModal } from '@/components/UI/ConfirmModal';
 import { Spinner } from '@/components/UI/Loading';
-import { Trash2, UserPlus, Ghost } from 'lucide-react';
+import { Trash2, UserPlus, Ghost, XCircle, PlusCircle } from 'lucide-react';
 
 interface EditGroupsFormProps {
   groups: Group[];
@@ -22,7 +22,63 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
   logout,
 }) => {
   const [processingId, setProcessingId] = useState<string | number | null>(null);
+  const [newGroupName, setNewGroupName] = useState('');
+  const [isCreatingNewGroup, setIsCreatingNewGroup] = useState(false);
   const { confirm, setIsLoading: setConfirmLoading, ConfirmModalComponent } = useConfirmModal();
+
+  const handleCreateGroup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newGroupName.trim() || isCreatingNewGroup) return;
+
+    setIsCreatingNewGroup(true);
+    setProcessingId('creating-new-group');
+    try {
+      const response = await authFetch(
+        '/api/assessment/create-group',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ nombre: newGroupName.trim() }),
+        },
+        () => logout()
+      );
+
+      if (response.ok) {
+        notify({
+          title: 'Grupo creado',
+          titleColor: 'var(--color-accent)',
+          subtitle: `El grupo "${newGroupName.trim()}" se creó correctamente`,
+          subtitleColor: 'var(--color-muted)',
+          borderColor: 'var(--color-accent)',
+          duration: 3000,
+        });
+        setNewGroupName('');
+        onRefresh();
+      } else {
+        const result = await response.json();
+        notify({
+          title: 'Error al crear grupo',
+          titleColor: 'var(--error)',
+          subtitle: result.error || 'Error al crear el grupo',
+          subtitleColor: 'var(--color-muted)',
+          borderColor: 'var(--error)',
+          duration: 4000,
+        });
+      }
+    } catch {
+      notify({
+        title: 'Error de red',
+        titleColor: 'var(--error)',
+        subtitle: 'Error al conectar con el servidor',
+        subtitleColor: 'var(--color-muted)',
+        borderColor: 'var(--error)',
+        duration: 4000,
+      });
+    } finally {
+      setIsCreatingNewGroup(false);
+      setProcessingId(null);
+    }
+  };
 
   const handleDeleteGroup = async (id: number) => {
     const isConfirmed = await confirm({
@@ -85,6 +141,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
   };
 
   const handleMoveParticipant = async (participantId: number, newGroupId: number | null) => {
+    if (processingId) return;
     setProcessingId(`part-${participantId}`);
     try {
       const response = await authFetch(
@@ -103,9 +160,9 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
 
       if (response.ok) {
         notify({
-          title: 'Cambio realizado',
+          title: newGroupId === null ? 'Participante desvinculado' : 'Cambio realizado',
           titleColor: 'var(--color-accent)',
-          subtitle: 'Se ha movido al participante correctamente',
+          subtitle: newGroupId === null ? 'Se ha quitado al participante del grupo' : 'Se ha movido al participante correctamente',
           subtitleColor: 'var(--color-muted)',
           borderColor: 'var(--color-accent)',
           duration: 2500,
@@ -116,7 +173,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
         notify({
           title: 'Error',
           titleColor: 'var(--error)',
-          subtitle: result.error || 'Error al mover participante',
+          subtitle: result.error || 'Error al procesar el cambio',
           subtitleColor: 'var(--color-muted)',
           borderColor: 'var(--error)',
           duration: 4000,
@@ -146,7 +203,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
   return (
     <div className="space-y-6">
 
-      <div className="bg-orange-50 border border-orange-100 rounded-xl p-4">
+      <div className={`bg-orange-50 border border-orange-100 rounded-xl p-4 transition-opacity ${processingId ? 'opacity-50 pointer-events-none' : ''}`}>
         <h3 className="text-sm font-bold text-orange-800 mb-3 flex items-center gap-2">
           <UserPlus className="w-4 h-4" />
           Participantes sin grupo ({unassignedParticipants.length})
@@ -167,8 +224,8 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
                 </div>
                 <select
                   onChange={(e) => handleMoveParticipant(p.id, Number(e.target.value))}
-                  disabled={processingId === `part-${p.id}`}
-                  className="bg-orange-100 text-orange-800 border-none rounded px-2 py-1 font-bold outline-none focus:ring-1 focus:ring-orange-400"
+                  disabled={!!processingId}
+                  className="bg-orange-100 text-orange-800 border-none rounded px-2 py-1 font-bold outline-none focus:ring-1 focus:ring-orange-400 disabled:opacity-50"
                   value=""
                 >
                   <option value="" disabled>Asignar a...</option>
@@ -182,18 +239,43 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
         )}
       </div>
 
+      <div className={`bg-gray-50 border border-gray-200 rounded-xl p-4 space-y-3 transition-opacity ${processingId ? 'opacity-50 pointer-events-none' : ''}`}>
+        <h3 className="text-sm font-bold text-gray-700 flex items-center gap-2">
+          <PlusCircle className="w-4 h-4" />
+          Añadir Grupo Manualmente
+        </h3>
+        <form onSubmit={handleCreateGroup} className="flex gap-2">
+          <input
+            type="text"
+            placeholder="Nombre del grupo (ej. Grupo 10)"
+            value={newGroupName}
+            onChange={(e) => setNewGroupName(e.target.value)}
+            disabled={!!processingId}
+            className="flex-1 bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-purple-400 outline-none transition disabled:opacity-50"
+          />
+          <button
+            type="submit"
+            disabled={!!processingId || !newGroupName.trim()}
+            className="bg-[color:var(--color-accent)] hover:bg-[#5B21B6] text-white px-4 py-2 rounded-lg text-sm font-bold transition flex items-center gap-2 disabled:opacity-50"
+          >
+            {isCreatingNewGroup ? <Spinner size="sm" /> : <PlusCircle className="w-4 h-4" />}
+            Crear
+          </button>
+        </form>
+      </div>
+
       <div className="space-y-4">
         <h3 className="text-sm font-bold text-gray-700">Grupos Existentes</h3>
         {groups.length === 0 ? (
           <div className="text-center py-8 bg-gray-50 rounded-xl text-gray-400 text-sm">
-            No hay grupos creados. Usa "Crear y sortear".
+            No hay grupos creados. Usa el sorteo automático o crea uno manual.
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-4">
             {groups.map((group) => (
               <div
                 key={group.id}
-                className="bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm"
+                className={`bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm transition-opacity ${processingId && !String(processingId).includes(String(group.id)) ? 'opacity-50 pointer-events-none' : ''}`}
               >
                 <div className="flex items-center justify-between p-3 bg-[color:var(--color-accent)] border-b border-gray-100">
                   <div className="flex items-center gap-2">
@@ -209,7 +291,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => handleDeleteGroup(group.id)}
-                      disabled={processingId === `group-${group.id}`}
+                      disabled={!!processingId}
                       className="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-colors disabled:opacity-50"
                       title="Eliminar grupo"
                     >
@@ -227,7 +309,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
                     <p className="text-[10px] text-gray-400 italic text-center py-2">Sin integrantes</p>
                   ) : (
                     participantsByGroup[group.id].map(p => (
-                      <div key={p.id} className="flex items-center justify-between group/item">
+                      <div key={p.id} className={`flex items-center justify-between group/item ${processingId === `part-${p.id}` ? 'opacity-50 pointer-events-none' : ''}`}>
                         <div className="flex items-center gap-2 truncate mr-2">
                           <span className="text-xs font-semibold text-gray-900 truncate max-w-[180px]">{p.nombre}</span>
                           {p.isImpostor && (
@@ -236,20 +318,31 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
                             </span>
                           )}
                         </div>
-                        <div className="flex items-center gap-1 opacity-0 group-hover/item:opacity-100 transition-opacity">
+                        <div className="flex items-center gap-1.5">
                           <select
-                            onChange={(e) => handleMoveParticipant(p.id, e.target.value === "none" ? null : Number(e.target.value))}
-                            disabled={processingId === `part-${p.id}`}
-                            className="text-[10px] bg-gray-100 hover:bg-purple-100 text-gray-600 border-none rounded px-1.5 py-0.5 outline-none"
-                            value={group.id}
+                            onChange={(e) => handleMoveParticipant(p.id, Number(e.target.value))}
+                            disabled={!!processingId}
+                            className="text-[10px] bg-transparent hover:bg-purple-100 text-gray-600 border border-gray-200 rounded px-1.5 py-0.5 outline-none transition disabled:opacity-50 cursor-pointer"
+                            value=""
                           >
-                            <option value="none">Desvincular</option>
-                            <optgroup label="Mover a...">
-                              {groups.filter(g => g.id !== group.id).map(g => (
-                                <option key={g.id} value={g.id}>{g.nombre}</option>
-                              ))}
-                            </optgroup>
+                            <option value="" disabled>Mover a...</option>
+                            {groups.filter(g => g.id !== group.id).map(g => (
+                              <option key={g.id} value={g.id}>{g.nombre}</option>
+                            ))}
                           </select>
+                          
+                          <button
+                            onClick={() => handleMoveParticipant(p.id, null)}
+                            disabled={!!processingId}
+                            title="Quitar del grupo"
+                            className="p-1 rounded-full bg-transparent hover:bg-red-50 text-gray-400 hover:text-red-500 transition-colors disabled:opacity-50"
+                          >
+                            {processingId === `part-${p.id}` ? (
+                              <Spinner size="sm" />
+                            ) : (
+                              <XCircle className="w-4 h-4" />
+                            )}
+                          </button>
                         </div>
                       </div>
                     ))

--- a/src/features/admin/configuration/components/EditGroupsForm.tsx
+++ b/src/features/admin/configuration/components/EditGroupsForm.tsx
@@ -69,7 +69,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
           duration: 4000,
         });
       }
-    } catch (err) {
+    } catch {
       notify({
         title: 'Error de red',
         titleColor: 'var(--error)',
@@ -122,7 +122,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
           duration: 4000,
         });
       }
-    } catch (err) {
+    } catch {
       notify({
         title: 'Error de red',
         titleColor: 'var(--error)',
@@ -136,7 +136,6 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
     }
   };
 
-  // Organizar participantes por grupo
   const participantsByGroup = groups.reduce((acc, group) => {
     acc[group.id] = participants.filter(p => p.grupoId === group.id);
     return acc;
@@ -146,7 +145,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
 
   return (
     <div className="space-y-6">
-      {/* Sección de Participantes sin Grupo */}
+
       <div className="bg-orange-50 border border-orange-100 rounded-xl p-4">
         <h3 className="text-sm font-bold text-orange-800 mb-3 flex items-center gap-2">
           <UserPlus className="w-4 h-4" />
@@ -155,7 +154,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
         {unassignedParticipants.length === 0 ? (
           <p className="text-xs text-orange-600 italic">Todos los participantes tienen grupo.</p>
         ) : (
-          <div className="space-y-2 max-h-40 overflow-y-auto pr-2 custom-scrollbar">
+          <div className="space-y-2 max-h-40 overflow-y-auto pr-2">
             {unassignedParticipants.map(p => (
               <div key={p.id} className="flex items-center justify-between bg-white p-2 rounded-lg border border-orange-200 text-xs">
                 <div className="flex items-center gap-2 truncate mr-2">
@@ -166,7 +165,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
                     </span>
                   )}
                 </div>
-                <select 
+                <select
                   onChange={(e) => handleMoveParticipant(p.id, Number(e.target.value))}
                   disabled={processingId === `part-${p.id}`}
                   className="bg-orange-100 text-orange-800 border-none rounded px-2 py-1 font-bold outline-none focus:ring-1 focus:ring-orange-400"
@@ -183,7 +182,6 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
         )}
       </div>
 
-      {/* Lista de Grupos */}
       <div className="space-y-4">
         <h3 className="text-sm font-bold text-gray-700">Grupos Existentes</h3>
         {groups.length === 0 ? (
@@ -193,33 +191,37 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
         ) : (
           <div className="grid grid-cols-1 gap-4">
             {groups.map((group) => (
-              <div 
-                key={group.id} 
+              <div
+                key={group.id}
                 className="bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm"
               >
-                {/* Header del Grupo */}
-                <div className="flex items-center justify-between p-3 bg-gray-50 border-b border-gray-100">
+                <div className="flex items-center justify-between p-3 bg-[color:var(--color-accent)] border-b border-gray-100">
                   <div className="flex items-center gap-2">
-                    <div className="w-8 h-8 bg-purple-600 text-white rounded-lg flex items-center justify-center font-bold text-xs">
+                    <div className="w-8 h-8 bg-white/20 text-white rounded-lg flex items-center justify-center font-bold text-xs">
                       {group.nombre.match(/\d+/)?.[0] || group.nombre.charAt(0)}
                     </div>
-                    <span className="font-bold text-gray-900">{group.nombre}</span>
-                    <span className="text-[10px] bg-gray-200 text-gray-600 px-1.5 py-0.5 rounded-full">
+                    <span className="font-bold text-white">{group.nombre}</span>
+                    <span className="text-[10px] bg-white/20 text-white px-1.5 py-0.5 rounded-full">
                       {participantsByGroup[group.id]?.length || 0} integrantes
                     </span>
                   </div>
-                  
-                  <button
-                    onClick={() => handleDeleteGroup(group.id)}
-                    disabled={processingId === `group-${group.id}`}
-                    className="p-1.5 text-gray-400 hover:text-red-500 transition"
-                    title="Eliminar grupo"
-                  >
-                    {processingId === `group-${group.id}` ? <Spinner size="sm" /> : <Trash2 className="w-4 h-4" />}
-                  </button>
+
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => handleDeleteGroup(group.id)}
+                      disabled={processingId === `group-${group.id}`}
+                      className="p-1.5 rounded-lg bg-white/20 hover:bg-white/30 transition-colors disabled:opacity-50"
+                      title="Eliminar grupo"
+                    >
+                      {processingId === `group-${group.id}` ? (
+                        <Spinner size="sm" />
+                      ) : (
+                        <Trash2 className="w-4 h-4 text-white" />
+                      )}
+                    </button>
+                  </div>
                 </div>
 
-                {/* Lista de Integrantes */}
                 <div className="p-3 space-y-2">
                   {(participantsByGroup[group.id] || []).length === 0 ? (
                     <p className="text-[10px] text-gray-400 italic text-center py-2">Sin integrantes</p>
@@ -235,7 +237,7 @@ export const EditGroupsForm: React.FC<EditGroupsFormProps> = ({
                           )}
                         </div>
                         <div className="flex items-center gap-1 opacity-0 group-hover/item:opacity-100 transition-opacity">
-                          <select 
+                          <select
                             onChange={(e) => handleMoveParticipant(p.id, e.target.value === "none" ? null : Number(e.target.value))}
                             disabled={processingId === `part-${p.id}`}
                             className="text-[10px] bg-gray-100 hover:bg-purple-100 text-gray-600 border-none rounded px-1.5 py-0.5 outline-none"

--- a/src/features/admin/configuration/components/ParticipantFiltersBar.tsx
+++ b/src/features/admin/configuration/components/ParticipantFiltersBar.tsx
@@ -55,7 +55,8 @@ export const ParticipantFiltersBar: React.FC<ParticipantFiltersBarProps> = ({
 
   return (
     <div className="w-full max-w-[900px] mb-4 px-1 sm:px-2">
-      <Box className="w-full space-y-3">
+      <Box className="w-full p-4 space-y-4">
+        <h2 className="text-lg font-bold text-gray-900 mb-4 text-center sm:text-left">Buscar y editar staff</h2>
 
         {/* Busqueda y filtros */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -78,6 +79,7 @@ export const ParticipantFiltersBar: React.FC<ParticipantFiltersBarProps> = ({
             className="px-3 py-2 rounded-lg bg-gray-50 text-gray-900 border border-transparent focus:bg-white focus:ring-2 focus:ring-[color:var(--color-accent)] outline-none transition text-sm"
           >
             <option value="todos">Todos los roles</option>
+            <option value="admin">Administradores</option>
             <option value="calificador">Calificadores</option>
             <option value="registrador">Registradores</option>
           </select>

--- a/src/features/admin/configuration/components/ParticipantFiltersBar.tsx
+++ b/src/features/admin/configuration/components/ParticipantFiltersBar.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { ArrowUp, ArrowDown, Search, X } from 'lucide-react';
+import { notify } from '@/components/UI/Notification';
 import { Box } from '@/components/UI/Box';
 
 interface ParticipantFiltersBarProps {
@@ -24,58 +26,97 @@ export const ParticipantFiltersBar: React.FC<ParticipantFiltersBarProps> = ({
   setSortOrder,
   setCurrentPage,
 }) => {
+  const hasActiveFilters = !!searchTerm || filterRol !== "todos";
+
+  const handleClearFilters = () => {
+    if (hasActiveFilters) {
+      setSearchTerm("");
+      setFilterRol("todos");
+      setCurrentPage(1);
+      notify({
+        title: "Filtros limpiados",
+        titleColor: "var(--color-accent)",
+        subtitle: "Se eliminaron todos los filtros activos",
+        subtitleColor: "var(--color-muted)",
+        borderColor: "var(--color-accent)",
+        duration: 3000,
+      });
+    } else {
+      notify({
+        title: "Sin filtros activos",
+        titleColor: "var(--warning)",
+        subtitle: "No hay filtros aplicados para limpiar",
+        subtitleColor: "var(--color-muted)",
+        borderColor: "var(--warning)",
+        duration: 2500,
+      });
+    }
+  };
+
   return (
     <div className="w-full max-w-[900px] mb-4 px-1 sm:px-2">
-      <Box className="p-4 sm:p-6 space-y-4">
-        <h2 className="text-lg font-bold text-gray-900 text-center sm:text-left">Buscar y editar Staff</h2>
-        
-        <div className="relative">
-          <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          <input
-            type="text"
-            placeholder="Buscar por correo..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 rounded-lg bg-white text-gray-900 placeholder-gray-400 border border-gray-300 focus:border-[color:var(--color-accent)] focus:outline-none transition text-base"
-          />
-        </div>
+      <Box className="w-full space-y-3">
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-          <div className="flex flex-col gap-1">
-            <label className="text-xs font-semibold text-gray-500 ml-1">Filtrar por Rol</label>
-            <select
-              value={filterRol}
-              onChange={(e) => { setFilterRol(e.target.value); setCurrentPage(1); }}
-              className="px-3 py-2 rounded-lg bg-white text-gray-900 border border-gray-300 text-base focus:ring-2 focus:ring-purple-200 outline-none transition"
-            >
-              <option value="todos">Todos los roles</option>
-              <option value="admin">Administrador</option>
-              <option value="calificador">Calificador</option>
-              <option value="registrador">Registrador</option>
-            </select>
+        {/* Busqueda y filtros */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+          <div className="relative lg:col-span-2">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+              <Search className="w-4 h-4" />
+            </span>
+            <input
+              type="text"
+              placeholder="Buscar por correo..."
+              value={searchTerm}
+              onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }}
+              className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-50 text-gray-900 border border-transparent focus:bg-white focus:ring-2 focus:ring-[color:var(--color-accent)] outline-none transition text-sm"
+            />
           </div>
 
-          <div className="flex flex-col gap-1">
-            <label className="text-xs font-semibold text-gray-500 ml-1">Ordenar por</label>
-            <div className="flex gap-1">
-              <select
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as "nombre" | "rol")}
-                className="flex-1 px-3 py-2 rounded-lg bg-white text-gray-900 border border-gray-300 text-sm focus:ring-2 focus:ring-purple-200 outline-none transition"
-              >
-                <option value="nombre">Por Correo</option>
-                <option value="rol">Por Rol</option>
-              </select>
-              <button
-                onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
-                className="px-3 py-2 rounded-lg bg-white border border-gray-300 hover:bg-gray-50 transition"
-                title={sortOrder === "asc" ? "Ascendente" : "Descendente"}
-              >
-                {sortOrder === "asc" ? "↑" : "↓"}
-              </button>
-            </div>
+          <select
+            value={filterRol}
+            onChange={(e) => { setFilterRol(e.target.value); setCurrentPage(1); }}
+            className="px-3 py-2 rounded-lg bg-gray-50 text-gray-900 border border-transparent focus:bg-white focus:ring-2 focus:ring-[color:var(--color-accent)] outline-none transition text-sm"
+          >
+            <option value="todos">Todos los roles</option>
+            <option value="calificador">Calificadores</option>
+            <option value="registrador">Registradores</option>
+          </select>
+        </div>
+
+        {/* Ordenar y limpiar */}
+        <div className="flex flex-wrap items-center gap-4 pt-2 border-t border-gray-100">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">Ordenar:</span>
+            <select
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as "nombre" | "rol")}
+              className="bg-transparent text-sm font-semibold text-gray-700 outline-none cursor-pointer"
+            >
+              <option value="nombre">Correo</option>
+              <option value="rol">Rol</option>
+            </select>
+            <button
+              onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
+              className="p-1 hover:bg-gray-100 rounded transition"
+            >
+              {sortOrder === "asc"
+                ? <ArrowUp className="w-3.5 h-3.5" />
+                : <ArrowDown className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+
+          <div className="ml-auto">
+            <button
+              onClick={handleClearFilters}
+              className={`flex items-center gap-1 text-xs whitespace-nowrap font-medium px-3 py-1.5 rounded-lg transition
+                ${hasActiveFilters
+                  ? "bg-[color:var(--color-accent)] text-white hover:bg-[#5B21B6]"
+                  : "bg-gray-300 text-gray-500 cursor-pointer hover:bg-gray-400"
+                }`}
+            >
+              <X className="w-3 h-3 shrink-0" />
+              Limpiar filtros
+            </button>
           </div>
         </div>
       </Box>

--- a/src/features/admin/configuration/components/RegisterStaffForm.tsx
+++ b/src/features/admin/configuration/components/RegisterStaffForm.tsx
@@ -38,21 +38,9 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
   return (
     <div className="w-full max-w-[900px] mb-4 px-1 sm:px-2">
       <Box className="p-4 sm:p-6">
+        <h2 className="text-lg font-bold text-gray-900 mb-6">Registrar Staff</h2>
 
-        {/* Header: titulo + boton alineados */}
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-bold text-gray-900">Registrar Staff</h2>
-          <Button
-            type="submit"
-            variant="accent"
-            loading={creatingStaff}
-            onClick={(e) => onSubmit(e as unknown as React.FormEvent)}
-          >
-            Registrar Staff
-          </Button>
-        </div>
-
-        <form onSubmit={onSubmit} className="flex flex-col gap-4">
+        <form onSubmit={onSubmit} className="flex flex-col gap-6">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <InputBox
               label="Correo"
@@ -60,6 +48,7 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
               placeholder="Correo del staff"
               value={staffCorreo}
               onChange={(e) => setStaffCorreo(e.target.value)}
+              disabled={creatingStaff}
             />
             <InputBox
               label="Contrasena"
@@ -67,6 +56,7 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
               placeholder="Contrasena"
               value={staffPassword}
               onChange={(e) => setStaffPassword(e.target.value)}
+              disabled={creatingStaff}
             />
           </div>
 
@@ -75,11 +65,13 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
               <label className="text-base font-semibold text-gray-700">Rol</label>
               <select
                 value={staffRol}
+                disabled={creatingStaff}
                 onChange={(e) => {
                   setStaffRol(e.target.value);
                   if (e.target.value === 'registrador') setStaffBaseId('');
                 }}
-                className="w-full px-4 py-3 rounded-lg bg-white border border-gray-300 text-gray-900 focus:outline-none focus:ring-2 focus:ring-purple-400 transition"
+                className={`w-full px-4 py-3 rounded-lg bg-white border border-gray-300 text-gray-900 focus:outline-none focus:ring-2 focus:ring-purple-400 transition
+                  ${creatingStaff ? 'bg-gray-100 cursor-not-allowed opacity-75' : ''}`}
               >
                 <option value="">Seleccionar rol</option>
                 <option value="calificador">Calificador</option>
@@ -89,15 +81,15 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
 
             {showBaseField && (
               <div className="flex flex-col gap-1">
-                <label className={`text-base font-semibold ${!isCalificador ? 'text-gray-400' : 'text-gray-700'}`}>
+                <label className={`text-base font-semibold ${!isCalificador || creatingStaff ? 'text-gray-400' : 'text-gray-700'}`}>
                   Base
                 </label>
                 <select
                   value={staffBaseId}
                   onChange={(e) => isCalificador && setStaffBaseId(e.target.value)}
-                  disabled={!isCalificador}
+                  disabled={!isCalificador || creatingStaff}
                   className={`w-full px-4 py-3 rounded-lg border transition focus:outline-none
-                    ${!isCalificador
+                    ${(!isCalificador || creatingStaff)
                       ? 'bg-gray-100 border-gray-300 text-gray-400 cursor-not-allowed'
                       : 'bg-white border-gray-300 text-gray-900 focus:ring-2 focus:ring-purple-400'
                     }`}
@@ -117,9 +109,19 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
                     )
                   )}
                 </select>
-
               </div>
             )}
+          </div>
+
+          <div className="flex justify-end pt-2">
+            <Button
+              type="submit"
+              variant="accent"
+              loading={creatingStaff}
+              className="w-full sm:w-auto px-12"
+            >
+              Registrar Staff
+            </Button>
           </div>
         </form>
       </Box>

--- a/src/features/admin/configuration/components/RegisterStaffForm.tsx
+++ b/src/features/admin/configuration/components/RegisterStaffForm.tsx
@@ -31,10 +31,27 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
   creatingStaff,
   onSubmit,
 }) => {
+  const isRegistrador = staffRol === 'registrador';
+  const isCalificador = staffRol === 'calificador';
+  const showBaseField = true;
+
   return (
     <div className="w-full max-w-[900px] mb-4 px-1 sm:px-2">
       <Box className="p-4 sm:p-6">
-        <h2 className="text-lg font-bold text-gray-900 mb-4">Registrar Staff</h2>
+
+        {/* Header: titulo + boton alineados */}
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-bold text-gray-900">Registrar Staff</h2>
+          <Button
+            type="submit"
+            variant="accent"
+            loading={creatingStaff}
+            onClick={(e) => onSubmit(e as unknown as React.FormEvent)}
+          >
+            Registrar Staff
+          </Button>
+        </div>
+
         <form onSubmit={onSubmit} className="flex flex-col gap-4">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <InputBox
@@ -45,9 +62,9 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
               onChange={(e) => setStaffCorreo(e.target.value)}
             />
             <InputBox
-              label="Contraseña"
+              label="Contrasena"
               type="password"
-              placeholder="Contraseña"
+              placeholder="Contrasena"
               value={staffPassword}
               onChange={(e) => setStaffPassword(e.target.value)}
             />
@@ -60,9 +77,7 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
                 value={staffRol}
                 onChange={(e) => {
                   setStaffRol(e.target.value);
-                  if (e.target.value === 'registrador') {
-                    setStaffBaseId('');
-                  }
+                  if (e.target.value === 'registrador') setStaffBaseId('');
                 }}
                 className="w-full px-4 py-3 rounded-lg bg-white border border-gray-300 text-gray-900 focus:outline-none focus:ring-2 focus:ring-purple-400 transition"
               >
@@ -72,37 +87,39 @@ export const RegisterStaffForm: React.FC<RegisterStaffFormProps> = ({
               </select>
             </div>
 
-            {staffRol === 'calificador' && (
+            {showBaseField && (
               <div className="flex flex-col gap-1">
-                <label className="text-base font-semibold text-gray-700">Base</label>
+                <label className={`text-base font-semibold ${!isCalificador ? 'text-gray-400' : 'text-gray-700'}`}>
+                  Base
+                </label>
                 <select
                   value={staffBaseId}
-                  onChange={(e) => setStaffBaseId(e.target.value)}
-                  className="w-full px-4 py-3 rounded-lg bg-white border border-gray-300 text-gray-900 focus:outline-none focus:ring-2 focus:ring-purple-400 transition"
+                  onChange={(e) => isCalificador && setStaffBaseId(e.target.value)}
+                  disabled={!isCalificador}
+                  className={`w-full px-4 py-3 rounded-lg border transition focus:outline-none
+                    ${!isCalificador
+                      ? 'bg-gray-100 border-gray-300 text-gray-400 cursor-not-allowed'
+                      : 'bg-white border-gray-300 text-gray-900 focus:ring-2 focus:ring-purple-400'
+                    }`}
                 >
-                  <option value="">Seleccionar Base</option>
-                  {basesList.length === 0 ? (
-                    <option value="" disabled>No hay bases para este assessment</option>
-                  ) : (
-                    basesList.map((b) => (
-                      <option key={b.ID_Base} value={String(b.ID_Base)}>
-                        {`Base ${b.Numero_Base} - ${b.Nombre_Base}`}
-                      </option>
-                    ))
+                  <option value="">
+                    {!isCalificador ? 'Solo editable para calificadores' : 'Seleccionar Base'}
+                  </option>
+                  {isCalificador && (
+                    basesList.length === 0 ? (
+                      <option value="" disabled>No hay bases para este assessment</option>
+                    ) : (
+                      basesList.map((b) => (
+                        <option key={b.ID_Base} value={String(b.ID_Base)}>
+                          {`Base ${b.Numero_Base} - ${b.Nombre_Base}`}
+                        </option>
+                      ))
+                    )
                   )}
                 </select>
+
               </div>
             )}
-          </div>
-          
-          <div className="flex justify-end mt-2">
-            <Button
-              type="submit"
-              loading={creatingStaff}
-              className="px-8 py-3"
-            >
-              Registrar {staffRol === 'calificador' ? 'Calificador' : staffRol === 'registrador' ? 'Registrador' : 'Staff'}
-            </Button>
           </div>
         </form>
       </Box>

--- a/src/features/admin/configuration/hooks/useParticipantsAndGroups.ts
+++ b/src/features/admin/configuration/hooks/useParticipantsAndGroups.ts
@@ -1,39 +1,40 @@
 import { useState, useCallback } from 'react';
 import { authFetch } from '@/lib/auth/authFetch';
 import { z } from 'zod';
-import { ParticipantSchema, GroupSchema, type Participant, type Group } from '../schemas/configSchemas';
+import { StaffSchema, GroupSchema, type Staff, type Group, type Participant, ParticipantSchema } from '../schemas/configSchemas';
 
 export function useParticipantsAndGroups(logout: () => void) {
+  const [staff, setStaff] = useState<Staff[]>([]);
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [groups, setGroups] = useState<Group[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const loadParticipantsAndGroups = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
     try {
-      const [participantsRes, groupsRes] = await Promise.all([
-        authFetch(
-          '/api/participante/list',
-          {},
-          () => logout()
-        ),
-        authFetch(
-          '/api/assessment/groups',
-          {},
-          () => logout()
-        ),
+      const [staffRes, groupsRes, participantsRes] = await Promise.all([
+        authFetch('/api/staff/list', {}, () => logout()),
+        authFetch('/api/assessment/groups', {}, () => logout()),
+        authFetch('/api/participante/list', {}, () => logout()),
       ]);
 
-      if (participantsRes.ok) {
-        const result = await participantsRes.json();
-        const parsed = z.array(ParticipantSchema).safeParse(result);
-        if (parsed.success) setParticipants(parsed.data || []);
+      if (staffRes.ok) {
+        const result = await staffRes.json();
+        const parsed = z.array(StaffSchema).safeParse(result);
+        if (parsed.success) setStaff(parsed.data || []);
+        else console.error('❌ Validation error (Staff):', parsed.error);
       }
 
       if (groupsRes.ok) {
         const result = await groupsRes.json();
         const parsed = z.array(GroupSchema).safeParse(result);
         if (parsed.success) setGroups(parsed.data || []);
+      }
+
+      if (participantsRes.ok) {
+        const result = await participantsRes.json();
+        const parsed = z.array(ParticipantSchema).safeParse(result);
+        if (parsed.success) setParticipants(parsed.data || []);
       }
     } catch (err) {
       console.error('❌ Error loading participants/groups:', err);
@@ -42,5 +43,5 @@ export function useParticipantsAndGroups(logout: () => void) {
     }
   }, [logout]);
 
-  return { participants, groups, loading, loadParticipantsAndGroups };
+  return { staff, participants, groups, loading, loadParticipantsAndGroups };
 }

--- a/src/features/admin/configuration/schemas/configSchemas.ts
+++ b/src/features/admin/configuration/schemas/configSchemas.ts
@@ -36,8 +36,17 @@ export const BaseSchema = z.object({
   Nombre_Base: z.string(),
 });
 
+export const StaffSchema = z.object({
+  ID: z.number(),
+  Correo: z.string().email(),
+  role: z.string(),
+  Active: z.boolean(),
+  idBase: z.number().nullable().optional(),
+});
+
 export type Calificacion = z.infer<typeof CalificacionSchema>;
 export type Assessment = z.infer<typeof AssessmentSchema>;
 export type Participant = z.infer<typeof ParticipantSchema>;
 export type Group = z.infer<typeof GroupSchema>;
 export type Base = z.infer<typeof BaseSchema>;
+export type Staff = z.infer<typeof StaffSchema>;

--- a/src/features/admin/management/GestionContainer.tsx
+++ b/src/features/admin/management/GestionContainer.tsx
@@ -31,6 +31,8 @@ import { handleExportCSV } from "./utils/gestionUtils";
 import { type ParticipantDashboardRow, type ClassificationRanges } from "./schemas/gestionSchemas";
 import { showToast } from "@/components/UI/Toast";
 
+import { BrandedLoading } from "@/components/UI/Loading";
+
 // ─── RangesInline — fuera del page para no perder foco ───────────────────────
 interface RangesInlineProps {
   localRanges: ClassificationRanges;
@@ -190,6 +192,8 @@ export const GestionContainer = () => {
 
   const { ConfirmModalComponent } = useConfirmModal();
 
+  const isInitialLoading = authLoading || (dataLoading && data.length === 0);
+
   const hasActiveFilters =
     !!searchTerm ||
     filterGrupo !== "todos" ||
@@ -230,32 +234,6 @@ export const GestionContainer = () => {
       });
     }
   };
-  if (authLoading || !isAdmin) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-white">
-        <Spinner size="xl" color="custom" customColor="var(--color-accent)" />
-        <p className="text-[color:var(--color-text)] text-xl mt-4">Verificando acceso...</p>
-      </div>
-    );
-  }
-
-  if (dataLoading && data.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen py-8 px-4 bg-white">
-        <div className="w-full max-w-7xl flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-extrabold text-[color:var(--color-accent)]">Gestión del Assessment</h1>
-        </div>
-        <div className="flex items-center gap-3 mb-6">
-          <Spinner size="lg" color="custom" customColor="var(--color-accent)" />
-          <span className="text-[color:var(--color-muted)] text-lg">Cargando datos...</span>
-        </div>
-        <div className="hidden lg:block w-full max-w-7xl bg-white shadow rounded-xl overflow-hidden border border-gray-100">
-          <div className="p-4 border-b"><Skeleton className="h-6 w-48" /></div>
-          {[1, 2, 3, 4, 5, 6].map((i) => <SkeletonTableRow key={i} />)}
-        </div>
-      </div>
-    );
-  }
 
   if (dataError) {
     return (
@@ -358,28 +336,42 @@ export const GestionContainer = () => {
 
       <div className="w-full max-w-7xl">
         <Box className="!p-0 overflow-hidden">
-          <ParticipantTable
-            paginatedData={paginatedData}
-            baseNumbers={baseNumbers}
-            getEstadoInfo={getEstadoInfo}
-            onEdit={openEditModal}
-            onDetail={setDetailModal}
-          />
-          <div className="px-4">
-            <ParticipantCardList
-              paginatedData={paginatedData}
-              getEstadoInfo={getEstadoInfo}
-              onEdit={openEditModal}
-              onDetail={setDetailModal}
-            />
-          </div>
-          <div className="px-4 pb-4">
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              setCurrentPage={setCurrentPage}
-            />
-          </div>
+          {dataLoading && data.length === 0 ? (
+            <div className="p-4 space-y-4">
+              <div className="flex items-center justify-between mb-4">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-8 w-24" />
+              </div>
+              {[1, 2, 3, 4, 5, 6].map((_, i) => (
+                <SkeletonTableRow key={i} index={i} />
+              ))}
+            </div>
+          ) : (
+            <>
+              <ParticipantTable
+                paginatedData={paginatedData}
+                baseNumbers={baseNumbers}
+                getEstadoInfo={getEstadoInfo}
+                onEdit={openEditModal}
+                onDetail={setDetailModal}
+              />
+              <div className="px-4">
+                <ParticipantCardList
+                  paginatedData={paginatedData}
+                  getEstadoInfo={getEstadoInfo}
+                  onEdit={openEditModal}
+                  onDetail={setDetailModal}
+                />
+              </div>
+              <div className="px-4 pb-4">
+                <Pagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  setCurrentPage={setCurrentPage}
+                />
+              </div>
+            </>
+          )}
         </Box>
       </div>
 

--- a/src/features/admin/management/hooks/useGestionData.ts
+++ b/src/features/admin/management/hooks/useGestionData.ts
@@ -5,7 +5,7 @@ import { ParticipantDashboardRowSchema, type ParticipantDashboardRow } from '../
 
 export function useGestionData(logout: () => void) {
   const [data, setData] = useState<ParticipantDashboardRow[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 

--- a/src/lib/assessment.ts
+++ b/src/lib/assessment.ts
@@ -55,9 +55,11 @@ export function getAuthorizedAssessmentId(
   if (!assessmentId) {
     if (user.id === SUPER_ADMIN_ID) {
       console.warn(`[getAuthorizedAssessmentId] Super-admin ${user.id} intentó acceder sin assessmentId en el token. Debe usar /api/auth/switch-assessment`);
-    } else {
-      console.warn(`[getAuthorizedAssessmentId] Usuario ${user.id} no tiene assessmentId en su token`);
-    }
+      res.status(403).json({ error: 'Debes seleccionar un assessment en el panel de super-admin' });
+      return null;
+    } 
+    
+    console.warn(`[getAuthorizedAssessmentId] Usuario ${user.id} no tiene assessmentId en su token`);
     clearSessionCookie(res);
     res.status(403).json({ error: 'No tienes un assessment asignado activo' });
     return null;

--- a/src/pages/api/assessment/auto-groups.ts
+++ b/src/pages/api/assessment/auto-groups.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '@/lib/supabase/server';
 import { requireRoles } from '@/lib/auth/apiAuth';
+import { getAuthorizedAssessmentId } from '@/lib/assessment';
 
 const shuffle = <T,>(arr: T[]) => {
   const copy = [...arr];
@@ -32,15 +33,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Método no permitido' });
   }
 
-  if (!await requireRoles(req, res, ['admin'])) return;
+  const user = await requireRoles(req, res, ['admin']);
+  if (!user) return;
 
-  const { assessmentId, numGroups } = req.body ?? {};
-  const assessmentIdNum = Number(assessmentId);
+  const assessmentId = getAuthorizedAssessmentId(user, res);
+  if (!assessmentId) return;
+
+  const { numGroups } = req.body ?? {};
   const groupCount = Number(numGroups);
-
-  if (!assessmentId || Number.isNaN(assessmentIdNum)) {
-    return res.status(400).json({ error: 'assessmentId es obligatorio' });
-  }
 
   if (!numGroups || Number.isNaN(groupCount) || groupCount <= 0) {
     return res.status(400).json({ error: 'numGroups debe ser un número válido' });
@@ -50,7 +50,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { data: participantes, error: participantesError } = await supabase
       .from('Participante')
       .select('ID_Participante, Rol_Participante')
-      .eq('ID_Assessment', assessmentIdNum)
+      .eq('ID_Assessment', assessmentId)
       .order('ID_Participante', { ascending: true });
 
     if (participantesError) {
@@ -92,7 +92,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { data: existingGroups, error: existingError } = await supabase
       .from('GrupoAssessment')
       .select('ID_GrupoAssessment, Nombre_GrupoAssessment')
-      .eq('ID_Assessment', assessmentIdNum)
+      .eq('ID_Assessment', assessmentId)
       .in('Nombre_GrupoAssessment', groupNames);
 
     if (existingError) {
@@ -112,7 +112,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .from('GrupoAssessment')
         .insert(
           missingGroupNames.map((name) => ({
-            ID_Assessment: assessmentIdNum,
+            ID_Assessment: assessmentId,
             Nombre_GrupoAssessment: name,
           }))
         )
@@ -130,7 +130,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { error: clearError } = await supabase
       .from('Participante')
       .update({ ID_GrupoAssessment: null })
-      .eq('ID_Assessment', assessmentIdNum);
+      .eq('ID_Assessment', assessmentId);
 
     if (clearError) {
       throw new Error(clearError.message);
@@ -149,7 +149,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .from('Participante')
         .update({ ID_GrupoAssessment: groupId })
         .in('ID_Participante', memberIds)
-        .eq('ID_Assessment', assessmentIdNum);
+        .eq('ID_Assessment', assessmentId);
 
       if (updateError) {
         throw new Error(updateError.message);

--- a/src/pages/api/assessment/create-group.ts
+++ b/src/pages/api/assessment/create-group.ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabase/server';
+import { requireRoles } from '@/lib/auth/apiAuth';
+import { getAuthorizedAssessmentId } from '@/lib/assessment';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Método no permitido' });
+  }
+
+  const user = await requireRoles(req, res, ['admin']);
+  if (!user) return;
+
+  const assessmentId = getAuthorizedAssessmentId(user, res);
+  if (!assessmentId) return;
+
+  const { nombre } = req.body ?? {};
+
+  if (!nombre || typeof nombre !== 'string' || nombre.trim() === '') {
+    return res.status(400).json({ error: 'El nombre del grupo es obligatorio' });
+  }
+
+  const cleanName = nombre.trim();
+
+  try {
+    // 1. Verificar duplicados en el mismo assessment
+    const { data: existing, error: checkError } = await supabase
+      .from('GrupoAssessment')
+      .select('ID_GrupoAssessment')
+      .eq('ID_Assessment', assessmentId)
+      .eq('Nombre_GrupoAssessment', cleanName)
+      .maybeSingle();
+
+    if (checkError) throw checkError;
+    if (existing) {
+      return res.status(400).json({ error: 'Ya existe un grupo con este nombre en el assessment' });
+    }
+
+    // 2. Insertar el nuevo grupo
+    const { data: newGroup, error: insertError } = await supabase
+      .from('GrupoAssessment')
+      .insert({
+        ID_Assessment: assessmentId,
+        Nombre_GrupoAssessment: cleanName,
+      })
+      .select('ID_GrupoAssessment, Nombre_GrupoAssessment')
+      .single();
+
+    if (insertError) throw insertError;
+
+    res.status(200).json({
+      message: 'Grupo creado exitosamente',
+      group: {
+        id: newGroup.ID_GrupoAssessment,
+        nombre: newGroup.Nombre_GrupoAssessment,
+      },
+    });
+  } catch (error) {
+    console.error('❌ Error al crear grupo manual:', error);
+    res.status(500).json({ error: 'Error interno al crear el grupo' });
+  }
+}

--- a/src/pages/api/assessment/groups-active.ts
+++ b/src/pages/api/assessment/groups-active.ts
@@ -11,16 +11,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
-  const assessmentId = user.id === 0 
-    ? Number(req.query.assessmentId) 
-    : getAuthorizedAssessmentId(user, res);
-
-  if (!assessmentId || Number.isNaN(assessmentId)) {
-    if (user.id === 0) {
-      return res.status(400).json({ error: 'assessmentId es obligatorio en el query para el super-admin' });
-    }
-    return; // getAuthorizedAssessmentId already sent the response
-  }
+  const assessmentId = getAuthorizedAssessmentId(user, res);
+  if (!assessmentId) return;
 
   try {
     const { data: participantes, error: participantesError } = await supabase

--- a/src/pages/api/assessment/groups.ts
+++ b/src/pages/api/assessment/groups.ts
@@ -3,6 +3,8 @@ import { supabase } from '@/lib/supabase/server';
 import { requireRoles } from '@/lib/auth/apiAuth';
 import { getAuthorizedAssessmentId } from '@/lib/assessment';
 
+
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Método no permitido' });
@@ -11,16 +13,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
-  const assessmentId = user.id === 0 
-    ? Number(req.query.assessmentId) 
-    : getAuthorizedAssessmentId(user, res);
-
-  if (!assessmentId || Number.isNaN(assessmentId)) {
-    if (user.id === 0) {
-      return res.status(400).json({ error: 'assessmentId es obligatorio en el query para el super-admin' });
-    }
-    return; // getAuthorizedAssessmentId already sent the response
-  }
+  const assessmentId = getAuthorizedAssessmentId(user, res);
+  if (!assessmentId) return;
 
   try {
     const { data, error } = await supabase

--- a/src/pages/api/dashboard/config.ts
+++ b/src/pages/api/dashboard/config.ts
@@ -1,7 +1,7 @@
 // pages/api/dashboard/config.ts
 import type { NextApiRequest, NextApiResponse } from "next";
 import { supabase } from "@/lib/supabase/server";
-import { verifyAssessmentAccess } from "@/lib/assessment";
+import { verifyAssessmentAccess, getAuthorizedAssessmentId } from "@/lib/assessment";
 import { requireRoles } from "@/lib/auth/apiAuth";
 import { resolveParticipantPhotoUrls } from "@/lib/utils/imageUrl";
 
@@ -11,10 +11,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const user = await requireRoles(req, res, ["admin"]);
     if (!user) return;
 
-    const assessmentId = user.assessmentId;
-    if (!verifyAssessmentAccess(user, assessmentId as number, res)) {
-      return;
-    }
+    const assessmentId = getAuthorizedAssessmentId(user, res);
+    if (!assessmentId) return;
 
     const { data: assessment, error: assessmentError } = await supabase
       .from('Assessment')

--- a/src/pages/api/dashboard/gh.ts
+++ b/src/pages/api/dashboard/gh.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { supabase } from "@/lib/supabase/server";
-import { verifyAssessmentAccess } from "@/lib/assessment";
+import { verifyAssessmentAccess, getAuthorizedAssessmentId } from "@/lib/assessment";
 import { requireRoles } from "@/lib/auth/apiAuth";
 import { resolveParticipantPhotoUrls } from "@/lib/utils/imageUrl";
 
@@ -9,16 +9,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const user = await requireRoles(req, res, ["admin"]);
     if (!user) return;
 
-    // Si viene assessmentId en el query param, usarlo; si no, usar el del token
-    const queryAssessmentId = req.query.assessmentId
-      ? Number(req.query.assessmentId)
-      : null;
-
-    const assessmentId = queryAssessmentId ?? user.assessmentId;
-
-    if (!verifyAssessmentAccess(user, assessmentId as number, res)) {
-      return;
-    }
+    const assessmentId = getAuthorizedAssessmentId(user, res);
+    if (!assessmentId) return;
 
     // Obtener participantes y su grupo
     const { data: participantes, error: participantesError } = await supabase

--- a/src/pages/api/participante/list.ts
+++ b/src/pages/api/participante/list.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '@/lib/supabase/server';
 import { requireRoles } from '@/lib/auth/apiAuth';
-import { verifyAssessmentAccess } from '@/lib/assessment';
+import { getAuthorizedAssessmentId } from '@/lib/assessment';
+
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -11,10 +12,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const user = await requireRoles(req, res, ['admin']);
   if (!user) return;
 
-  const assessmentId = user.assessmentId;
-  if (!verifyAssessmentAccess(user, assessmentId as number, res)) {
-    return;
-  }
+  const assessmentId = getAuthorizedAssessmentId(user, res);
+  if (!assessmentId) return;
 
   try {
     const { data, error } = await supabase

--- a/src/pages/api/staff/create.ts
+++ b/src/pages/api/staff/create.ts
@@ -6,7 +6,7 @@ import { getAuthorizedAssessmentId } from '@/lib/assessment';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Método no permitido' });
+    return res.status(405).json({ error: 'Metodo no permitido' });
   }
 
   const user = await requireRoles(req, res, ['admin']);
@@ -15,15 +15,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { correo, password, rol, idBase } = req.body;
 
   const assessmentId = getAuthorizedAssessmentId(user, res);
-  if (!assessmentId) return; // La función ya responde con 403 y destruye la cookie si no hay acceso
+  if (!assessmentId) return;
 
   if (!correo || !password || !rol) {
     return res.status(400).json({ error: 'correo, password y rol son obligatorios' });
   }
-  
+
   try {
-    // Validar que el Base pertenezca al Assessment si se proporciona
-    
     if (idBase) {
       const { data: baseData, error: baseError } = await supabase
         .from('Bases')
@@ -33,10 +31,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       if (baseError || !baseData || baseData.ID_Assessment !== Number(assessmentId)) {
         return res.status(400).json({ error: 'El Base no pertenece a este Assessment' });
-        
       }
     }
-      
 
     const hashedPassword = await hashPassword(password);
 
@@ -49,7 +45,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ID_Base: idBase ? Number(idBase) : null,
     };
 
-    console.log('📝 Intentando insertar en Staff:', staffData);
+    console.log('Intentando insertar en Staff:', staffData);
 
     const { data, error } = await supabase
       .from('Staff')
@@ -57,13 +53,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       .select('ID_Staff')
       .single();
 
-    if (error || !data) {
-      throw new Error(error?.message || 'Error creando staff');
+    if (error) {
+      // Correo duplicado — unique constraint de Supabase/Postgres
+      if (error.code === '23505') {
+        return res.status(409).json({ error: `El correo ${correo} ya esta registrado como staff` });
+      }
+      throw new Error(error.message);
     }
 
-    res.status(200).json({ message: 'Calificador registrado', ID_Staff: data.ID_Staff });
+    if (!data) {
+      throw new Error('No se pudo crear el staff');
+    }
+
+    res.status(200).json({ message: 'Staff registrado', ID_Staff: data.ID_Staff });
   } catch (error) {
-    console.error('❌ Error al crear staff:', error);
-    res.status(500).json({ error: 'Error al crear staff' });
+    console.error('Error al crear staff:', error);
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Error inesperado al crear staff',
+    });
   }
 }


### PR DESCRIPTION
## Related work item
Closes #85, #133, #134

## Summary
Refactor completo de la vista de Configuración del Assessment y optimización de la experiencia de carga administrativa. Se migraron los componentes al design system global (Box, Button, InputBox), se implementó el efecto **Brand Shimmer Wave** en todos los skeleton loaders, se estandarizó la seguridad de APIs mediante assessmentId basado en JWT y se añadió la capacidad de creación manual de grupos.

## Context
La vista de configuración requería alineación con el resto del proyecto y una experiencia de carga más fluida para eliminar el parpadeo de componentes. Además, era necesario unificar la lógica de contexto del assessment para el Super Admin tras la implementación de Switch Assessment, eliminando parámetros obsoletos por URL.

## Testing
- [x] `npm run lint` passes without new errors
- [x] `npm run build` completes successfully
- [x] `npx vitest run` passes (159 tests)

## Impact
- **UX Premium:** Implementación de esqueletos con efecto shimmer y branding púrpura con carga escalonada (ola).
- **Seguridad:** APIs administrativas (/groups, /participante/list, /dashboard/*) ahora son deterministas y dependen exclusivamente del token de sesión.
- **Funcionalidad:** Los administradores pueden crear grupos manualmente y desvincular participantes con un flujo UX mejorado (XCircle local).
- **UI Configuración:** Formulario de registro de staff con validación de roles, filtros avanzados con soporte para 'Administradores' y notificaciones centralizadas con el componente `notify`.